### PR TITLE
style(frontend): 优化页面动画效果并移除多余动画类

### DIFF
--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -28,7 +28,7 @@
     <main class="flex-1 overflow-y-auto">
       <div class="container mx-auto pt-4 pb-14">
         <transition name="page" mode="out-in">
-          <router-view class="animate-fade-in"></router-view>
+          <router-view></router-view>
         </transition>
       </div>
     </main>
@@ -79,20 +79,15 @@ const handleLogout = async () => {
 </script>
 
 <style scoped>
-/* 页面过渡动画 */
+/* 页面过渡动画：纯淡入淡出，时间短，避免晃动 */
 .page-enter-active,
 .page-leave-active {
-  transition: all 0.3s ease-out;
+  transition: opacity 0.15s ease-out;
 }
 
-.page-enter-from {
-  opacity: 0;
-  transform: translateY(10px);
-}
-
+.page-enter-from,
 .page-leave-to {
   opacity: 0;
-  transform: translateY(-10px);
 }
 
 /* Tabbar 样式优化 */

--- a/frontend/src/views/Categories.vue
+++ b/frontend/src/views/Categories.vue
@@ -1,13 +1,13 @@
 <template>
-  <div class="min-h-screen animate-fade-in">
+  <div class="min-h-screen">
     <div class="mx-auto px-4 pb-6 pt-2">
-      <div class="mb-6 animate-fade-in-up">
+      <div class="mb-6">
         <h1 class="text-3xl font-display font-bold text-gray-900 mb-2">分类管理</h1>
         <p class="text-sm text-gray-600 font-medium">管理您的支出分类和标签，方便记录日常开销</p>
       </div>
 
       <!-- Tab 切换 -->
-      <div class="border-b border-warm-200 mb-6 animate-fade-in-up" style="animation-delay: 0.1s">
+      <div class="border-b border-warm-200 mb-6">
         <nav class="-mb-px flex space-x-8">
           <button
             v-for="tab in tabs"

--- a/frontend/src/views/Expenses.vue
+++ b/frontend/src/views/Expenses.vue
@@ -2,13 +2,13 @@
   <div class="min-h-screen">
     <div class="mx-auto px-4 pb-6 pt-2">
       <!-- 欢迎区域 -->
-      <div class="mb-4 animate-fade-in-up">
+      <div class="mb-4">
         <h1 class="text-3xl font-display font-bold text-gray-900 mb-2">支出记录</h1>
         <p class="text-sm text-gray-600 font-medium">今天是 {{ currentDate }}</p>
       </div>
 
       <!-- 搜索框和筛选器 -->
-      <div class="flex items-center space-x-2 mb-4 animate-fade-in-up" style="animation-delay: 0.1s">
+      <div class="flex items-center space-x-2 mb-4">
         <van-search
           v-model="searchQuery"
           placeholder="搜索支出记录（支持搜索'额外支出'）"
@@ -27,7 +27,7 @@
       </div>
 
       <!-- 当前筛选器显示 -->
-      <div v-if="currentFilter" class="mb-4 p-3 bg-warm-50 border border-warm-200 rounded-xl animate-scale-in">
+      <div v-if="currentFilter" class="mb-4 p-3 bg-warm-50 border border-warm-200 rounded-xl">
         <div class="flex items-center justify-between">
           <div class="flex items-center space-x-2">
             <van-icon name="filter-o" class="text-warm-600" size="18" />
@@ -62,7 +62,7 @@
       </div>
 
       <!-- 搜索区域 -->
-      <div class="bg-white/90 backdrop-blur-sm rounded-2xl shadow-warm p-4 pt-2 mb-6 animate-fade-in-up" :class="{ 'opacity-50': currentFilter }" style="animation-delay: 0.2s">
+      <div class="bg-white/90 backdrop-blur-sm rounded-2xl shadow-warm p-4 pt-2 mb-6" :class="{ 'opacity-50': currentFilter }">
         <div v-if="currentFilter" class="mb-3 p-3 bg-warm-100 rounded-xl border border-warm-300">
           <div class="flex items-center space-x-2">
             <van-icon name="info-o" class="text-warm-600" size="18" />
@@ -104,7 +104,7 @@
       </div>
 
       <!-- 支出列表 -->
-      <div class="bg-white/90 backdrop-blur-sm rounded-2xl shadow-warm p-4 animate-fade-in-up" style="animation-delay: 0.3s">
+      <div class="bg-white/90 backdrop-blur-sm rounded-2xl shadow-warm p-4">
         <div class="flex justify-between items-center mb-4">
           <div class="flex items-center space-x-3">
             <h2 class="text-xl font-display font-bold text-gray-900">支出记录</h2>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="container mx-auto px-4 animate-fade-in">
+  <div class="container mx-auto px-4">
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
 
       <!-- 预算卡片 -->
-      <div class="bg-white/90 backdrop-blur-sm rounded-2xl shadow-warm p-6 mb-4 card-hover animate-fade-in-up" style="animation-delay: 0.1s">
+      <div class="bg-white/90 backdrop-blur-sm rounded-2xl shadow-warm p-6 mb-4 card-hover">
         <div class="flex justify-between items-center mb-6">
           <h2 class="text-xl font-display font-bold text-gray-900">本月总览</h2>
           <van-button
@@ -55,7 +55,7 @@
       </div>
 
       <!-- 最近支出 -->
-      <div class="bg-white/90 backdrop-blur-sm rounded-2xl shadow-warm p-6 card-hover animate-fade-in-up" style="animation-delay: 0.2s">
+      <div class="bg-white/90 backdrop-blur-sm rounded-2xl shadow-warm p-6 card-hover">
         <div class="flex justify-between items-center mb-6">
           <h2 class="text-xl font-display font-bold text-gray-900">最近支出</h2>
           <div class="flex space-x-2">

--- a/frontend/src/views/Reports.vue
+++ b/frontend/src/views/Reports.vue
@@ -2,13 +2,13 @@
   <div class="min-h-screen">
     <div class="mx-auto px-4 pb-6 pt-2">
       <!-- 欢迎区域 -->
-      <div class="mb-4 animate-fade-in-up">
+      <div class="mb-4">
         <h1 class="text-3xl font-display font-bold text-gray-900 mb-2">报表分析</h1>
         <p class="text-sm text-gray-600 font-medium">今天是 {{ currentDate }}</p>
       </div>
 
       <!-- 搜索区域 -->
-       <div class="py-2.5 animate-fade-in-up" style="animation-delay: 0.1s">
+       <div class="py-2.5">
         <div class="bg-white/90 backdrop-blur-sm rounded-2xl shadow-warm p-4 mb-6">
           <div class="grid grid-cols-2 gap-4">
             <van-field
@@ -38,7 +38,7 @@
        </div>
 
       <!-- 总金额统计卡片 -->
-      <div class="bg-gradient-to-r from-red-500 to-red-600 rounded-2xl shadow-lg p-6 mb-4 animate-scale-in card-hover" style="animation-delay: 0.2s">
+      <div class="bg-gradient-to-r from-red-500 to-red-600 rounded-2xl shadow-lg p-6 mb-4 card-hover">
         <div class="text-center">
           <h3 class="text-white text-sm font-semibold mb-3 uppercase tracking-wide">时间段总支出</h3>
           <div class="text-white text-4xl font-display font-bold">
@@ -48,7 +48,7 @@
       </div>
 
       <!-- 额外支出统计卡片 -->
-      <div class="bg-gradient-to-r from-warm-500 to-warm-600 rounded-2xl shadow-lg p-6 mb-4 animate-scale-in card-hover" style="animation-delay: 0.3s">
+      <div class="bg-gradient-to-r from-warm-500 to-warm-600 rounded-2xl shadow-lg p-6 mb-4 card-hover">
         <div class="text-center">
           <h3 class="text-white text-sm font-semibold mb-3 uppercase tracking-wide">额外支出</h3>
           <div class="text-white text-4xl font-display font-bold">
@@ -61,16 +61,13 @@
       <trend-analysis
         :data="reportData.trend"
         :loading="loading"
-        class="mb-6 animate-fade-in-up"
-        style="animation-delay: 0.4s"
+        class="mb-6"
       />
 
       <!-- 分类分析 -->
       <category-analysis
         :data="reportStore.data"
         :loading="loading"
-        class="animate-fade-in-up"
-        style="animation-delay: 0.5s"
       />
 
       <!-- 日期选择器 -->


### PR DESCRIPTION
- 统一页面过渡动画为纯淡入淡出，缩短过渡时间避免视觉晃动
- 移除 MainLayout.vue 中 router-view 的 animate-fade-in 类
- 取消 Categories.vue、Expenses.vue、Home.vue 和 Reports.vue 中多处 animate-fade-in 和 animate-fade-in-up 动画类
- 删除相关内联动画延迟样式，简化动画表现
- 保持界面布局和功能不变，提升样式性能与用户体验

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes navigation/page transitions to a short, pure fade for smoother rendering and fewer motion artifacts.
> 
> - MainLayout: replace page transition with opacity-only `transition` (0.15s); remove `animate-fade-in` from `router-view`
> - Views (Categories, Expenses, Home, Reports): remove `animate-fade-in`/`animate-fade-in-up` classes and inline animation delays; retain existing layouts and logic
> - Keeps tab transition in Categories; no functional behavior changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 373327d1c8ac23cc10eb7e0c0b62f5ad753db70b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->