### PR TITLE
feat: 优化支出表单日期保留功能

### DIFF
--- a/frontend/src/components/ExpenseForm.vue
+++ b/frontend/src/components/ExpenseForm.vue
@@ -276,6 +276,11 @@ const toggle = (index: number) => {
 // 重置表单数据
 const resetForm = () => {
   form.date = dayjs().format('YYYY-MM-DD');
+  currentDate.value = [
+    dayjs().year().toString(),
+    (dayjs().month() + 1).toString().padStart(2, '0'),
+    dayjs().date().toString().padStart(2, '0')
+  ];
   form.category = '';
   form.amount = '';
   form.description = '';
@@ -312,6 +317,9 @@ const currentDate = ref<string[]>([
   (dayjs().month() + 1).toString().padStart(2, '0'),
   dayjs().date().toString().padStart(2, '0')
 ]);
+
+// 保存上次提交的日期，用于提交后保留日期
+const lastSubmittedDate = ref<string | null>(null);
 
 // 分类选择器
 const showCategoryPicker = ref(false);
@@ -400,7 +408,11 @@ const handleSubmit = async () => {
       showToast('保存成功');
     }
     emit('success');
-    resetForm(); // 提交成功后重置表单
+    // 只在新增模式下保存日期，用于下次打开表单时保留
+    if (!isEditMode.value) {
+      lastSubmittedDate.value = form.date;
+    }
+    resetForm();
     handleClose();
   } catch (error) {
     console.error('Failed to create expense:', error);
@@ -420,6 +432,17 @@ watch(() => props.show, async (newValue) => {
   if (newValue) {
     // 重置表单
     resetForm();
+    
+    // 如果是新增模式且有保留的日期，恢复保留的日期
+    if (!isEditMode.value && lastSubmittedDate.value) {
+      form.date = lastSubmittedDate.value;
+      const dateObj = dayjs(lastSubmittedDate.value);
+      currentDate.value = [
+        dateObj.year().toString(),
+        (dateObj.month() + 1).toString().padStart(2, '0'),
+        dateObj.date().toString().padStart(2, '0')
+      ];
+    }
     
           // 确保分类列表已加载
       if (categoryStore.allCategoriesForMapping.length === 0) {

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -27,9 +27,11 @@
     <!-- 中间内容区域 -->
     <main class="flex-1 overflow-y-auto">
       <div class="container mx-auto pt-4 pb-14">
-        <transition name="page" mode="out-in">
-          <router-view></router-view>
-        </transition>
+        <router-view v-slot="{ Component }">
+          <transition name="page" mode="out-in">
+            <component :is="Component" />
+          </transition>
+        </router-view>
       </div>
     </main>
 

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -200,7 +200,7 @@
   background: linear-gradient(135deg, var(--color-warm-500) 0%, var(--color-warm-600) 100%) !important;
   box-shadow: 0 8px 24px rgba(249, 115, 22, 0.35), 0 4px 12px rgba(249, 115, 22, 0.2) !important;
   border: 2px solid rgba(255, 255, 255, 0.3) !important;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important;
+  /* transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important; */
 }
 
 .van-floating-bubble:active {

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -2,7 +2,6 @@ import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import axios from '@/utils/axios';
 import { useRouter } from 'vue-router';
-;
 import CryptoJS from 'crypto-js';
 
 // 加密密钥（实际项目中应该从环境变量或配置中获取）

--- a/frontend/src/stores/budget.ts
+++ b/frontend/src/stores/budget.ts
@@ -1,7 +1,6 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import { budgetApi } from '@/api/budget';
-;
 import type { Budget } from '@/types/budget';
 
 const defaultBudget: Budget = {

--- a/frontend/src/stores/expense.ts
+++ b/frontend/src/stores/expense.ts
@@ -1,7 +1,6 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import { expenseApi } from '@/api/expense';
-;
 import type { ExpenseData, ExpenseQuery, ExpenseStats } from '@/api/expense';
 import dayjs from '@/utils/dayjs';
 

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -90,6 +90,7 @@
 
     <!-- 悬浮按钮 -->
     <van-floating-bubble
+      v-if="!showAddExpenseDialog"
       axis="xy"
       magnetic="x"
       :gap="{ x: 24, y: 60 }"


### PR DESCRIPTION
- 在 ExpenseForm 中添加日期保留逻辑，提交后保留上次使用的日期
- 优化 MainLayout 布局样式
- 清理 stores 中的冗余代码
- 更新样式文件

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Expense form date persistence**
> 
> - Stores the last submitted date (`lastSubmittedDate`) when adding expenses and restores it on reopen; keeps `currentDate` in sync. 
> - `resetForm` now also resets `currentDate`; show watcher restores saved date only in non-edit mode.
> 
> **Layout and UI tweaks**
> 
> - Refactors `MainLayout` to use `<router-view v-slot="{ Component }">` with a transition around `<component :is="Component" />` for cleaner page transitions.
> - Comments out the transition on `.van-floating-bubble` in `main.css` and hides the bubble while the add-expense dialog is open in `Home.vue`.
> 
> **Minor cleanup**
> 
> - Removes stray code artifacts in `stores/*` (e.g., superfluous semicolons/import noise).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50b491cd4983959306ce1cf0fa607adb1b40580d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->