### PR TITLE
fix: 支出列表金额超过10000时不再换行，支持百万级显示

### DIFF
--- a/frontend/src/components/ExpenseListItem.vue
+++ b/frontend/src/components/ExpenseListItem.vue
@@ -175,9 +175,10 @@ const handleDelete = () => {
 }
 
 :deep(.van-cell__value) {
-  @apply text-lg font-display font-bold text-warm-600 ml-2;
+  @apply text-lg font-display font-bold text-warm-600 ml-2 whitespace-nowrap;
   flex-shrink: 0;
   flex: 35%;
+  min-width: 8rem; /* 支持百万级金额不换行，约 ¥1234567.89 */
   transition: color 0.2s ease;
 }
 


### PR DESCRIPTION
本 PR 对应 Issue #27

**问题**：支出列表金额超过 10000 时金额会换行。

**改动**：
- 在 `ExpenseListItem.vue` 中为金额区域（`.van-cell__value`）添加 `whitespace-nowrap`，防止金额换行
- 设置 `min-width: 8rem`，保证百万级金额（如 ¥1234567.89）也能单行完整显示

Fixes #27

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, CSS-only change scoped to `ExpenseListItem.vue`; main risk is minor layout/overflow differences on very small screens.
> 
> **Overview**
> Prevents the amount text in the expense list item from wrapping by adding `whitespace-nowrap` to `.van-cell__value` and enforcing a `min-width: 8rem`, so larger (up to million-level) currency values stay on a single line.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f863a087aea11c573d3548279a8fe7d053d0e23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->