### PR TITLE
feat: 所有显示金额的地方添加千位分隔符

### DIFF
--- a/frontend/src/components/CategoryAnalysis.vue
+++ b/frontend/src/components/CategoryAnalysis.vue
@@ -21,7 +21,7 @@
                 <span class="text-lg mr-2">{{ item.icon }}</span>
                 <span class="text-gray-700 font-medium">{{ item.name }}</span>
               </div>
-              <span class="text-gray-900 font-display font-bold text-lg">¥{{ item.value.toFixed(2) }}</span>
+              <span class="text-gray-900 font-display font-bold text-lg">{{ formatAmount(item.value) }}</span>
             </div>
           </div>
         </div>
@@ -49,7 +49,7 @@
                 <span class="text-lg mr-2">{{ item.icon }}</span>
                 <span class="text-gray-700 font-medium">{{ item.name }}</span>
               </div>
-              <span class="text-gray-900 font-display font-bold text-lg">¥{{ item.value.toFixed(2) }}</span>
+              <span class="text-gray-900 font-display font-bold text-lg">{{ formatAmount(item.value) }}</span>
             </div>
           </div>
         </div>
@@ -76,7 +76,7 @@
                 ></div>
                 <span class="text-gray-700 font-medium">{{ item.name }}</span>
               </div>
-              <span class="text-gray-900 font-display font-bold text-lg">¥{{ item.value.toFixed(2) }}</span>
+              <span class="text-gray-900 font-display font-bold text-lg">{{ formatAmount(item.value) }}</span>
             </div>
           </div>
         </div>
@@ -89,6 +89,7 @@
 import { useReportStore } from '@/stores/report';
 import { useCategoryStore } from '@/stores/category';
 import { useTagStore } from '@/stores/tag';
+import { formatAmount } from '@/utils/format';
 import * as echarts from 'echarts';
 import type { ReportData } from '@/api/report';
 
@@ -212,7 +213,8 @@ const initChart = (chartRef: HTMLElement, data: Array<{ name: string; value: num
   const option = {
     tooltip: {
       trigger: 'item',
-      formatter: '{a} <br/>{b}: ¥{c} ({d}%)'
+      formatter: (params: any) =>
+        `${params.seriesName} <br/>${params.name}: ${formatAmount(params.value)} (${params.percent}%)`
     },
     series: [
       {

--- a/frontend/src/components/ExpenseListItem.vue
+++ b/frontend/src/components/ExpenseListItem.vue
@@ -68,6 +68,7 @@
 import { useCategoryStore } from '@/stores/category'
 import { useTagStore } from '@/stores/tag'
 import dayjs from '@/utils/dayjs'
+import { formatAmount } from '@/utils/format'
 import type { CategoryData } from '@/api/category'
 import type { TagData } from '@/api/tag'
 
@@ -133,11 +134,6 @@ const getCategoryIcon = (category: string | CategoryData) => {
 // 格式化日期
 const formatDate = (date: string) => {
   return dayjs(date).format('YYYY-MM-DD')
-}
-
-// 格式化金额
-const formatAmount = (amount: number) => {
-  return `¥${amount.toFixed(2)}`
 }
 
 // 处理编辑

--- a/frontend/src/components/FilterForm.vue
+++ b/frontend/src/components/FilterForm.vue
@@ -254,6 +254,7 @@
 import { useFilterStore } from '@/stores/filter'
 import { useTagStore } from '@/stores/tag'
 import { useCategoryStore } from '@/stores/category'
+import { formatAmount } from '@/utils/format'
 import MultiSelect from './MultiSelect.vue'
 import type { FilterData, FilterConditions } from '@/api/filter'
 
@@ -387,7 +388,7 @@ const amountRangeText = computed(() => {
     gte: '大于等于',
     lte: '小于等于'
   }
-  return `${operatorMap[conditions.amountRange.operator]} ¥${conditions.amountRange.value}`
+  return `${operatorMap[conditions.amountRange.operator]} ${formatAmount(conditions.amountRange.value)}`
 })
 
 const operatorText = computed(() => {

--- a/frontend/src/components/FilterManager.vue
+++ b/frontend/src/components/FilterManager.vue
@@ -143,6 +143,7 @@
 import { useFilterStore } from '@/stores/filter'
 import { useCategoryStore } from '@/stores/category'
 import { useTagStore } from '@/stores/tag'
+import { formatAmount } from '@/utils/format'
 import type { FilterData } from '@/api/filter'
 import FilterForm from './FilterForm.vue'
 import dayjs from '@/utils/dayjs'
@@ -273,7 +274,7 @@ const formatFilterConditions = (conditions: any) => {
       lte: '小于等于'
     }
     const operator = conditions.amountRange.operator
-    parts.push(`${operatorMap[operator]} ¥${conditions.amountRange.value}`)
+    parts.push(`${operatorMap[operator]} ${formatAmount(conditions.amountRange.value)}`)
   } else {
     parts.push('不限')
   }

--- a/frontend/src/components/TrendAnalysis.vue
+++ b/frontend/src/components/TrendAnalysis.vue
@@ -50,6 +50,7 @@
 <script setup lang="ts">
 import { useReportStore } from '@/stores/report';
 import dayjs from '@/utils/dayjs';
+import { formatAmount } from '@/utils/format';
 import * as echarts from 'echarts';
 
 interface Props {
@@ -116,7 +117,7 @@ const initChart = (chartRef: HTMLElement) => {
       },
       formatter: function(params: any) {
         const data = params[0];
-        return `${data.name}<br/>支出: ¥${data.value.toFixed(2)}`;
+        return `${data.name}<br/>支出: ${formatAmount(data.value)}`;
       }
     },
     grid: {
@@ -137,7 +138,7 @@ const initChart = (chartRef: HTMLElement) => {
     yAxis: {
       type: 'value',
       axisLabel: {
-        formatter: '¥{value}'
+        formatter: (value: number) => formatAmount(value)
       }
     },
     series: [
@@ -189,7 +190,7 @@ const updateChart = () => {
       },
       formatter: function(params: any) {
         const data = params[0];
-        return `${data.name}<br/>支出: ¥${data.value.toFixed(2)}`;
+        return `${data.name}<br/>支出: ${formatAmount(data.value)}`;
       }
     },
     grid: {
@@ -210,7 +211,7 @@ const updateChart = () => {
     yAxis: {
       type: 'value',
       axisLabel: {
-        formatter: '¥{value}'
+        formatter: (value: number) => formatAmount(value)
       }
     },
     series: [

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,0 +1,19 @@
+/**
+ * 将数字格式化为带千位分隔符的字符串（仅数字部分，不含货币符号）
+ * 例如：1234567.89 -> "1,234,567.89"
+ */
+export function formatNumberWithSeparator(value: number | undefined | null): string {
+  if (value === undefined || value === null || isNaN(value)) return '0.00'
+  const fixed = Number(value).toFixed(2)
+  const [intPart, decPart] = fixed.split('.')
+  const withSep = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+  return `${withSep}.${decPart}`
+}
+
+/**
+ * 格式化金额显示（带 ¥ 和千位分隔符）
+ * 例如：1234567.89 -> "¥1,234,567.89"
+ */
+export function formatAmount(value: number | undefined | null): string {
+  return `¥${formatNumberWithSeparator(value)}`
+}

--- a/frontend/src/views/Expenses.vue
+++ b/frontend/src/views/Expenses.vue
@@ -109,7 +109,7 @@
           <div class="flex items-center space-x-3">
             <h2 class="text-xl font-display font-bold text-gray-900">支出记录</h2>
             <span class="inline-flex items-center px-4 py-1.5 rounded-full text-sm font-bold bg-gradient-to-r from-red-500 to-red-600 text-white shadow-md">
-              总计: ¥{{ totalAmount.toFixed(2) }}
+              总计: {{ formatAmount(totalAmount) }}
             </span>
           </div>
         </div>
@@ -182,6 +182,7 @@ import FilterManager from '@/components/FilterManager.vue';
 import type { ExpenseQuery } from '@/api/expense';
 import type { FilterData } from '@/api/filter';
 import dayjs from '@/utils/dayjs';
+import { formatAmount } from '@/utils/format';
 
 const route = useRoute();
 const expenseStore = useExpenseStore();

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -115,6 +115,7 @@ import { useBudgetStore } from '@/stores/budget';
 import { useExpenseStore } from '@/stores/expense';
 import { useCategoryStore } from '@/stores/category';
 import { useTagStore } from '@/stores/tag';
+import { formatAmount } from '@/utils/format'
 import BudgetDialog from '@/components/BudgetDialog.vue';
 import ExpenseForm from '@/components/ExpenseForm.vue';
 import ExpenseList from '@/components/ExpenseList.vue';
@@ -150,12 +151,6 @@ const actualProgress = computed(() => {
   if (!budgetStore.currentBudget || !budgetStore.currentBudget.amount) return 0;
   return (monthlyExpense.value / budgetStore.currentBudget.amount) * 100;
 });
-
-// 格式化金额
-const formatAmount = (amount?: number) => {
-  if (!amount) return '¥0.00';
-  return `¥${amount.toFixed(2)}`;
-};
 
 // 处理刷新 - 同时刷新本月和最近数据
 const handleRefresh = async () => {

--- a/frontend/src/views/Reports.vue
+++ b/frontend/src/views/Reports.vue
@@ -42,7 +42,7 @@
         <div class="text-center">
           <h3 class="text-white text-sm font-semibold mb-3 uppercase tracking-wide">时间段总支出</h3>
           <div class="text-white text-4xl font-display font-bold">
-            ¥{{ totalAmount.toFixed(2) }}
+            {{ formatAmount(totalAmount) }}
           </div>
         </div>
       </div>
@@ -52,7 +52,7 @@
         <div class="text-center">
           <h3 class="text-white text-sm font-semibold mb-3 uppercase tracking-wide">额外支出</h3>
           <div class="text-white text-4xl font-display font-bold">
-            ¥{{ extraAmount.toFixed(2) }}
+            {{ formatAmount(extraAmount) }}
           </div>
         </div>
       </div>
@@ -100,6 +100,7 @@
 import TrendAnalysis from '@/components/TrendAnalysis.vue';
 import CategoryAnalysis from '@/components/CategoryAnalysis.vue';
 import { useReportStore } from '@/stores/report';
+import { formatAmount } from '@/utils/format';
 import type { ReportData } from '@/api/report';
 import dayjs from '@/utils/dayjs';
 


### PR DESCRIPTION
## 说明
本 PR 对应 Issue #28：所有显示金额的地方添加千位分隔符。

## 改动摘要
- **新增** `frontend/src/utils/format.ts`：`formatAmount`、`formatNumberWithSeparator`，统一金额展示格式（如 `¥1,234.56`）。
- **首页** `Home.vue`：预算、支出使用 `formatAmount`。
- **支出列表项** `ExpenseListItem.vue`：列表金额使用 `formatAmount`。
- **报表** `Reports.vue`：时间段总支出、额外支出卡片使用 `formatAmount`。
- **支出页** `Expenses.vue`：列表顶部「总计」使用 `formatAmount`。
- **趋势分析** `TrendAnalysis.vue`：图表 tooltip、Y 轴刻度使用千位分隔。
- **分类分析** `CategoryAnalysis.vue`：图例金额、饼图 tooltip 使用 `formatAmount`。
- **筛选器** `FilterManager.vue`、`FilterForm.vue`：金额条件展示使用 `formatAmount`。

## 验收
- 仅**展示**金额处使用千位分隔；输入框仍为原始数字，未改。
- 构建与 lint 已通过；本地打开首页可看到金额展示（当前为 ¥0.00，有数据时为千位分隔）。

Closes #28

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatting refactor with a small footprint; main risk is inconsistent formatting or unexpected `null/undefined/NaN` rendering in edge cases.
> 
> **Overview**
> Introduces a shared `frontend/src/utils/format.ts` with `formatAmount`/`formatNumberWithSeparator` to standardize money display as `¥1,234.56`.
> 
> Updates all major UI surfaces that *display* amounts (Home, Expenses total, Reports totals, expense list items, filter condition summaries) to use `formatAmount`, and adjusts ECharts tooltips/axis labels in `TrendAnalysis`/`CategoryAnalysis` to format values consistently (including pie tooltip formatter).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 702131558dcb21bf42fa22d67d4ec08316b32b05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->