### PR TITLE
feat(frontend): 新增支出日历与更多页并优化导航样式

### DIFF
--- a/frontend/src/api/expense.ts
+++ b/frontend/src/api/expense.ts
@@ -32,6 +32,21 @@ export interface ExpenseStats {
   byTag: Record<string, number>
 }
 
+export type ExpenseCategoryStatRow = {
+  _id: string
+  total: number
+}
+
+export type ExpenseDateStatRow = {
+  _id: string
+  total: number
+}
+
+export type ExpenseStatsResponse = {
+  categoryStats: ExpenseCategoryStatRow[]
+  dateStats: ExpenseDateStatRow[]
+}
+
 class ExpenseApi {
   private baseUrl = '/expenses'
 
@@ -52,7 +67,7 @@ class ExpenseApi {
 
   async getStats(query?: ExpenseQuery) {
     const response = await axios.get(`${this.baseUrl}/stats`, { params: query })
-    return response.data
+    return response.data as ExpenseStatsResponse
   }
 
   async delete(id: string): Promise<void> {

--- a/frontend/src/components/CalendarMonthPanel.vue
+++ b/frontend/src/components/CalendarMonthPanel.vue
@@ -1,0 +1,103 @@
+<template>
+  <section class="space-y-3">
+    <div class="px-1 flex items-center justify-between">
+      <div class="text-lg font-display font-bold text-gray-900">
+        {{ monthStart.format('YYYY年MM月') }}
+      </div>
+      <div class="text-sm text-gray-600 font-medium">
+        月合计 {{ formatAmount(monthTotal) }}
+      </div>
+    </div>
+
+    <div class="bg-white/90 rounded-2xl overflow-hidden calendar-panel pt-2">
+      <van-calendar
+        type="single"
+        :poppable="false"
+        :show-title="false"
+        :show-confirm="false"
+        :lazy-render="false"
+        :readonly="true"
+        :show-mark="false"
+        :show-subtitle="false"
+        :row-height="64"
+        :min-date="minDate"
+        :max-date="maxDate"
+        :default-date="defaultDate"
+        :formatter="formatDay"
+        :safe-area-inset-bottom="false"
+      />
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import type { CalendarDayItem } from 'vant/es/calendar/types'
+import dayjs from '@/utils/dayjs'
+import { formatAmount } from '@/utils/format'
+
+const props = defineProps<{
+  monthStart: dayjs.Dayjs
+  byDate: Record<string, number>
+}>()
+
+const minDate = computed(() => props.monthStart.startOf('month').toDate())
+const maxDate = computed(() => props.monthStart.endOf('month').toDate())
+
+const defaultDate = computed(() => {
+  const today = dayjs()
+  return props.monthStart.isSame(today, 'month')
+    ? today.toDate()
+    : props.monthStart.startOf('month').toDate()
+})
+
+const monthTotal = computed(() => {
+  const start = props.monthStart.startOf('month')
+  const end = props.monthStart.endOf('month')
+
+  let sum = 0
+  let cursor = start
+  while (cursor.isSame(end, 'day') || cursor.isBefore(end, 'day')) {
+    const key = cursor.format('YYYY-MM-DD')
+    sum += props.byDate[key] || 0
+    cursor = cursor.add(1, 'day')
+  }
+
+  return sum
+})
+
+const formatDay = (day: CalendarDayItem) => {
+  if (!day.date) {
+    return day
+  }
+
+  const d = dayjs(day.date)
+  if (d.isBefore(props.monthStart, 'month') || d.isAfter(props.monthStart, 'month')) {
+    day.type = 'disabled'
+    day.topInfo = ''
+    day.bottomInfo = ''
+    return day
+  }
+
+  const key = d.format('YYYY-MM-DD')
+  const amount = props.byDate[key] || 0
+
+  day.topInfo = ''
+  day.bottomInfo = amount > 0 ? formatAmount(amount) : ''
+
+  const isToday = d.isSame(dayjs(), 'day')
+  if (isToday) {
+    day.text = '今'
+  }
+  if (!isToday && day.type === 'selected') {
+    day.type = ''
+  }
+
+  return day
+}
+</script>
+
+<style scoped>
+.calendar-panel :deep(.van-calendar__month-title) {
+  display: none;
+}
+</style>

--- a/frontend/src/components/CalendarMonthRangeSearch.vue
+++ b/frontend/src/components/CalendarMonthRangeSearch.vue
@@ -1,0 +1,195 @@
+<template>
+  <div class="bg-white/90 backdrop-blur-sm rounded-2xl shadow-warm p-4 pt-2 mb-6">
+    <div class="grid grid-cols-2 gap-4">
+      <van-field
+        :model-value="formattedStartMonth"
+        readonly
+        is-link
+        placeholder="开始月份"
+        class="[&_.van-field]:bg-[color:var(--color-warm-50)] [&_.van-field]:rounded-xl [&_.van-field]:border [&_.van-field]:border-[color:var(--color-warm-200)] [&_.van-field:focus-within]:bg-white [&_.van-field:focus-within]:border-[color:var(--color-warm-400)] [&_.van-field:focus-within]:shadow-[0_0_0_3px_rgba(249,115,22,0.1)] [&_.van-field\_\_control]:text-sm [&_.van-field\_\_control]:text-slate-900 [&_.van-field\_\_control]:font-[family-name:var(--font-body)] [&_.van-field\_\_placeholder]:text-slate-400"
+        @click="openStartPicker"
+      />
+      <van-field
+        :model-value="formattedEndMonth"
+        readonly
+        is-link
+        placeholder="结束月份"
+        class="[&_.van-field]:bg-[color:var(--color-warm-50)] [&_.van-field]:rounded-xl [&_.van-field]:border [&_.van-field]:border-[color:var(--color-warm-200)] [&_.van-field:focus-within]:bg-white [&_.van-field:focus-within]:border-[color:var(--color-warm-400)] [&_.van-field:focus-within]:shadow-[0_0_0_3px_rgba(249,115,22,0.1)] [&_.van-field\_\_control]:text-sm [&_.van-field\_\_control]:text-slate-900 [&_.van-field\_\_control]:font-[family-name:var(--font-body)] [&_.van-field\_\_placeholder]:text-slate-400"
+        @click="openEndPicker"
+      />
+    </div>
+
+    <div class="mt-4">
+      <van-button size="small" type="primary" class="w-full rounded-lg" @click="emitSearch">
+        查询
+      </van-button>
+    </div>
+  </div>
+
+  <van-popup v-model:show="showStartPicker" position="bottom" round>
+    <van-date-picker
+      v-model="selectedStartMonth"
+      type="year-month"
+      title="选择开始月份"
+      :min-date="pickerMinDate"
+      :max-date="pickerMaxDate"
+      :columns-type="['year', 'month']"
+      @confirm="onStartMonthConfirm"
+      @cancel="showStartPicker = false"
+    />
+  </van-popup>
+
+  <van-popup v-model:show="showEndPicker" position="bottom" round>
+    <van-date-picker
+      v-model="selectedEndMonth"
+      type="year-month"
+      title="选择结束月份"
+      :min-date="pickerMinDate"
+      :max-date="pickerMaxDate"
+      :columns-type="['year', 'month']"
+      @confirm="onEndMonthConfirm"
+      @cancel="showEndPicker = false"
+    />
+  </van-popup>
+</template>
+
+<script setup lang="ts">
+import dayjs from '@/utils/dayjs'
+
+const props = defineProps<{
+  startMonth: string
+  endMonth: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'search', payload: { startMonth: string; endMonth: string }): void
+}>()
+
+const showStartPicker = ref(false)
+const showEndPicker = ref(false)
+
+const selectedStartMonth = ref<string[]>([])
+const selectedEndMonth = ref<string[]>([])
+
+const snapshotSelectedMonths = () => {
+  return {
+    start: [...selectedStartMonth.value],
+    end: [...selectedEndMonth.value]
+  }
+}
+
+const restoreSelectedMonths = (snapshot: { start: string[]; end: string[] }) => {
+  selectedStartMonth.value = [...snapshot.start]
+  selectedEndMonth.value = [...snapshot.end]
+}
+
+const pickerMinDate = new Date(2020, 0, 1)
+const pickerMaxDate = new Date(dayjs().add(5, 'year').year(), 11, 31)
+
+const formattedStartMonth = computed(() => {
+  if (selectedStartMonth.value.length !== 2) return ''
+  const [year, month] = selectedStartMonth.value
+  return `${year}年${month}月`
+})
+
+const formattedEndMonth = computed(() => {
+  if (selectedEndMonth.value.length !== 2) return ''
+  const [year, month] = selectedEndMonth.value
+  return `${year}年${month}月`
+})
+
+const syncFromProps = () => {
+  const start = dayjs(`${props.startMonth}-01`)
+  const end = dayjs(`${props.endMonth}-01`)
+
+  if (!start.isValid() || !end.isValid()) {
+    return
+  }
+
+  selectedStartMonth.value = [
+    start.year().toString(),
+    (start.month() + 1).toString().padStart(2, '0')
+  ]
+
+  selectedEndMonth.value = [
+    end.year().toString(),
+    (end.month() + 1).toString().padStart(2, '0')
+  ]
+}
+
+watch(
+  () => [props.startMonth, props.endMonth],
+  () => {
+    // 只在父组件“查询成功并更新 props”后同步，避免用户在选择过程中被旧值反复覆盖
+    syncFromProps()
+  }
+)
+
+const monthSpanInclusive = (start: dayjs.Dayjs, end: dayjs.Dayjs) => {
+  return end.startOf('month').diff(start.startOf('month'), 'month') + 1
+}
+
+const normalizeMonths = () => {
+  if (selectedStartMonth.value.length !== 2 || selectedEndMonth.value.length !== 2) {
+    showToast('请选择完整的月份范围')
+    return null
+  }
+
+  let start = dayjs(`${selectedStartMonth.value[0]}-${selectedStartMonth.value[1]}-01`).startOf('month')
+  let end = dayjs(`${selectedEndMonth.value[0]}-${selectedEndMonth.value[1]}-01`).startOf('month')
+
+  if (!start.isValid() || !end.isValid()) {
+    showToast('请选择有效的月份范围')
+    return null
+  }
+
+  if (end.isBefore(start, 'month')) {
+    const tmp = start
+    start = end
+    end = tmp
+  }
+
+  if (monthSpanInclusive(start, end) > 3) {
+    showToast('一次最多查询三个月')
+    return null
+  }
+
+  return {
+    startMonth: start.format('YYYY-MM'),
+    endMonth: end.format('YYYY-MM')
+  }
+}
+
+const openStartPicker = () => {
+  showStartPicker.value = true
+}
+
+const openEndPicker = () => {
+  showEndPicker.value = true
+}
+
+const onStartMonthConfirm = ({ selectedValues }: { selectedValues: string[] }) => {
+  selectedStartMonth.value = selectedValues
+  showStartPicker.value = false
+}
+
+const onEndMonthConfirm = ({ selectedValues }: { selectedValues: string[] }) => {
+  selectedEndMonth.value = selectedValues
+  showEndPicker.value = false
+}
+
+const emitSearch = () => {
+  const snapshot = snapshotSelectedMonths()
+  const normalized = normalizeMonths()
+  if (!normalized) {
+    restoreSelectedMonths(snapshot)
+    return
+  }
+
+  emit('search', normalized)
+}
+
+onMounted(() => {
+  syncFromProps()
+})
+</script>

--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -1,0 +1,17 @@
+<template>
+  <header class="flex flex-col gap-1.5">
+    <h1 class="text-2xl font-display font-bold text-gray-900 leading-tight">
+      {{ title }}
+    </h1>
+    <p v-if="description" class="text-sm text-gray-600 font-medium leading-relaxed">
+      {{ description }}
+    </p>
+  </header>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  title: string
+  description?: string
+}>()
+</script>

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -1,42 +1,23 @@
 <template>
-  <div class="h-screen bg-gradient-warm-subtle flex flex-col">
-    <!-- 顶部导航栏 -->
-    <nav class="z-10 bg-white/80 backdrop-blur-md shadow-md border-b border-warm-100 sticky top-0">
-      <div class="container mx-auto px-4">
-        <div class="flex justify-between items-center h-16">
-          <div class="flex items-center space-x-8">
-            <router-link 
-              to="/" 
-              class="text-xl font-display font-bold bg-gradient-to-r from-warm-600 to-warm-500 bg-clip-text text-transparent hover:from-warm-700 hover:to-warm-600 transition-all duration-300"
-            >
-              家庭账本
-            </router-link>
-          </div>
-          <div class="flex items-center space-x-4">
-            <button 
-              @click="handleLogout" 
-              class="px-4 py-2 text-sm font-medium text-gray-700 hover:text-warm-600 hover:bg-warm-50 rounded-lg transition-all duration-200 hover:shadow-sm"
-            >
-              退出登录
-            </button>
-          </div>
-        </div>
-      </div>
-    </nav>
-
+  <div class="h-screen overflow-hidden bg-gradient-warm-subtle flex flex-col">
     <!-- 中间内容区域 -->
-    <main class="flex-1 overflow-y-auto">
-      <div class="container mx-auto pt-4 pb-14">
+    <main class="flex-1 min-h-0 overflow-y-auto">
+      <div class="container mx-auto pt-2 pb-2">
         <router-view v-slot="{ Component }">
-          <transition name="page" mode="out-in">
-            <component :is="Component" />
-          </transition>
+          <component :is="Component" />
         </router-view>
       </div>
     </main>
 
     <!-- 移动端底部导航 -->
-    <van-tabbar v-model="active" class="md:hidden border-t border-warm-200 bg-white/90 backdrop-blur-md" @change="handleTabChange">
+    <van-tabbar
+      v-model="active"
+      :fixed="false"
+      safe-area-inset-bottom
+      :border="false"
+      class="md:hidden bg-transparent"
+      @change="handleTabChange"
+    >
       <van-tabbar-item
         v-for="item in navItems"
         :key="item.path"
@@ -49,60 +30,75 @@
 </template>
 
 <script setup lang="ts">
-import { useAuthStore } from '@/stores/auth';
-
-const router = useRouter();
-const route = useRoute();
-const authStore = useAuthStore();
+const router = useRouter()
+const route = useRoute()
 
 const navItems = [
   { name: '首页', path: '/', icon: 'home-o' },
   { name: '支出', path: '/expenses', icon: 'balance-o' },
-  { name: '分类', path: '/categories', icon: 'apps-o' },
-  { name: '报表', path: '/reports', icon: 'chart-trending-o' }
-];
+  { name: '日历', path: '/calendar', icon: 'calendar-o' },
+  { name: '更多', path: '/more', icon: 'more-o' }
+]
 
 // 将 active 改为 ref，初始值根据当前路由计算
-const active = ref(0);
+const active = ref(0)
 
 // 监听路由变化，自动更新 active 值
 watch(() => route.path, (newPath) => {
-  const index = navItems.findIndex(item => item.path === newPath);
-  active.value = index !== -1 ? index : 0;
-}, { immediate: true });
+  const index = navItems.findIndex(item => item.path === newPath)
+
+  if (index !== -1) {
+    active.value = index
+    return
+  }
+
+  // 从“更多”进入的页面，保持底部高亮为“更多”
+  if (newPath === '/reports' || newPath === '/categories') {
+    const moreIndex = navItems.findIndex(item => item.path === '/more')
+    active.value = moreIndex === -1 ? 0 : moreIndex
+    return
+  }
+
+  active.value = 0
+}, { immediate: true })
 
 const handleTabChange = (index: number) => {
-  router.push(navItems[index].path);
-};
-
-const handleLogout = async () => {
-  await authStore.logout();
-};
+  router.push(navItems[index].path)
+}
 </script>
 
 <style scoped>
-/* 页面过渡动画：纯淡入淡出，时间短，避免晃动 */
-.page-enter-active,
-.page-leave-active {
-  transition: opacity 0.15s ease-out;
-}
-
-.page-enter-from,
-.page-leave-to {
-  opacity: 0;
-}
-
 /* Tabbar 样式优化 */
 :deep(.van-tabbar) {
-  box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.05);
+  --van-tabbar-background: transparent;
+  box-shadow: none;
+  background: transparent;
+  border: 0;
+  backdrop-filter: none;
+}
+
+:deep(.van-tabbar::before),
+:deep(.van-tabbar::after) {
+  display: none;
+  content: none;
 }
 
 :deep(.van-tabbar-item) {
+  --van-tabbar-item-active-background: transparent;
+  background: transparent;
+  border: 0;
   @apply text-gray-500 transition-colors duration-200;
 }
 
 :deep(.van-tabbar-item--active) {
+  background: transparent;
   @apply text-warm-600;
+}
+
+:deep(.van-tabbar-item::before),
+:deep(.van-tabbar-item::after) {
+  display: none;
+  content: none;
 }
 
 :deep(.van-tabbar-item__icon) {

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -211,4 +211,55 @@
 .van-floating-bubble .van-icon {
   color: white !important;
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.15));
+}
+
+/* 全局“更纯粹”的视觉：去掉阴影/边框/动效（用 !important 覆盖 Tailwind 与 Vant 的默认装饰） */
+*,
+*::before,
+*::after {
+  box-shadow: none !important;
+  text-shadow: none !important;
+  filter: none !important;
+  -webkit-text-stroke: 0 !important;
+}
+
+/* 边框：保留结构但去掉可见描边（比直接 border:0 更不容易把布局挤变形） */
+*,
+*::before,
+*::after {
+  border-color: transparent !important;
+}
+
+/* 动效：禁用 CSS 动画/过渡（包含页面切换、hover 过渡、Vant 默认过渡） */
+*,
+*::before,
+*::after {
+  animation: none !important;
+  transition: none !important;
+  scroll-behavior: auto !important;
+}
+
+/* 项目里用到的动画工具类：直接失效（避免仍残留 animation-name） */
+[class*='animate-'] {
+  animation: none !important;
+}
+
+/* 卡片 hover 预设：去掉位移动画与阴影（即使 transition 已被禁用，也避免 hover 规则残留） */
+.card-hover:hover {
+  transform: none !important;
+  box-shadow: none !important;
+}
+
+/* 悬浮记账按钮：同步去掉阴影与描边，避免和全局规则“打架” */
+.van-floating-bubble {
+  box-shadow: none !important;
+  border: 0 !important;
+}
+
+.van-floating-bubble:active {
+  box-shadow: none !important;
+}
+
+.van-floating-bubble .van-icon {
+  filter: none !important;
 } 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -25,6 +25,14 @@ const router = createRouter({
           }
         },
         {
+          path: 'calendar',
+          name: 'calendar',
+          component: () => import('@/views/Calendar.vue'),
+          meta: {
+            requiresAuth: true
+          }
+        },
+        {
           path: 'categories',
           name: 'categories',
           component: () => import('@/views/Categories.vue'),
@@ -36,6 +44,14 @@ const router = createRouter({
           path: 'reports',
           name: 'reports',
           component: () => import('@/views/Reports.vue'),
+          meta: {
+            requiresAuth: true
+          }
+        },
+        {
+          path: 'more',
+          name: 'more',
+          component: () => import('@/views/More.vue'),
           meta: {
             requiresAuth: true
           }

--- a/frontend/src/views/Calendar.vue
+++ b/frontend/src/views/Calendar.vue
@@ -1,0 +1,120 @@
+<template>
+  <div>
+    <div class="mx-auto px-4 pb-6 pt-2">
+      <div class="mb-4">
+        <PageHeader title="支出日历" />
+      </div>
+
+      <CalendarMonthRangeSearch
+        :start-month="queryStartMonth"
+        :end-month="queryEndMonth"
+        @search="handleSearch"
+      />
+
+      <div v-if="loading" class="py-10 flex justify-center">
+        <van-loading type="spinner" />
+      </div>
+
+      <div v-else class="space-y-8">
+        <CalendarMonthPanel
+          v-for="month in months"
+          :key="month.format('YYYY-MM')"
+          :month-start="month"
+          :by-date="byDate"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { expenseApi, type ExpenseStatsResponse } from '@/api/expense'
+import dayjs from '@/utils/dayjs'
+import PageHeader from '@/components/PageHeader.vue'
+import CalendarMonthRangeSearch from '@/components/CalendarMonthRangeSearch.vue'
+import CalendarMonthPanel from '@/components/CalendarMonthPanel.vue'
+
+const loading = ref(true)
+const byDate = ref<Record<string, number>>({})
+
+const queryStartMonth = ref(dayjs().subtract(2, 'month').format('YYYY-MM'))
+const queryEndMonth = ref(dayjs().format('YYYY-MM'))
+
+const months = computed(() => {
+  let start = dayjs(`${queryStartMonth.value}-01`).startOf('month')
+  let end = dayjs(`${queryEndMonth.value}-01`).startOf('month')
+
+  if (!start.isValid() || !end.isValid()) {
+    return []
+  }
+
+  if (end.isBefore(start, 'month')) {
+    const tmp = start
+    start = end
+    end = tmp
+  }
+
+  const list: dayjs.Dayjs[] = []
+  let cursor = end
+
+  while (!cursor.isBefore(start, 'month')) {
+    list.push(cursor)
+    cursor = cursor.subtract(1, 'month')
+  }
+
+  return list
+})
+
+const handleSearch = async (payload: { startMonth: string; endMonth: string }) => {
+  queryStartMonth.value = payload.startMonth
+  queryEndMonth.value = payload.endMonth
+  await load()
+}
+
+const load = async () => {
+  loading.value = true
+  try {
+    const start = dayjs(`${queryStartMonth.value}-01`).startOf('month')
+    const end = dayjs(`${queryEndMonth.value}-01`).endOf('month')
+
+    const data: ExpenseStatsResponse = await expenseApi.getStats({
+      startDate: start.format('YYYY-MM-DD'),
+      endDate: end.format('YYYY-MM-DD')
+    })
+
+    const map: Record<string, number> = {}
+    const dateStats = Array.isArray(data?.dateStats) ? data.dateStats : []
+
+    for (const row of dateStats) {
+      const date = row?._id
+      const total = row?.total
+      if (typeof date === 'string' && typeof total === 'number') {
+        map[date] = total
+      }
+    }
+
+    byDate.value = map
+  } catch (error) {
+    console.error('Failed to load calendar stats:', error)
+    showToast('加载日历数据失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(() => {
+  load()
+})
+</script>
+
+<style scoped>
+:deep(.van-button--primary) {
+  background: linear-gradient(135deg, var(--color-warm-500) 0%, var(--color-warm-600) 100%);
+  border: none;
+  box-shadow: var(--shadow-warm);
+}
+
+:deep(.van-button--primary:active) {
+  background: linear-gradient(135deg, var(--color-warm-600) 0%, var(--color-warm-700) 100%);
+}
+</style>

--- a/frontend/src/views/Categories.vue
+++ b/frontend/src/views/Categories.vue
@@ -1,9 +1,11 @@
 <template>
-  <div class="min-h-screen">
+  <div>
     <div class="mx-auto px-4 pb-6 pt-2">
       <div class="mb-6">
-        <h1 class="text-3xl font-display font-bold text-gray-900 mb-2">分类管理</h1>
-        <p class="text-sm text-gray-600 font-medium">管理您的支出分类和标签，方便记录日常开销</p>
+        <PageHeader
+          title="分类管理"
+          description="管理您的支出分类和标签，方便记录日常开销"
+        />
       </div>
 
       <!-- Tab 切换 -->
@@ -45,6 +47,7 @@
 <script setup lang="ts">
 import CategoryList from '@/components/CategoryList.vue';
 import TagList from '@/components/TagList.vue';
+import PageHeader from '@/components/PageHeader.vue';
 
 // Tab 相关
 const tabs = [

--- a/frontend/src/views/Expenses.vue
+++ b/frontend/src/views/Expenses.vue
@@ -1,10 +1,9 @@
 <template>
-  <div class="min-h-screen">
+  <div>
     <div class="mx-auto px-4 pb-6 pt-2">
       <!-- 欢迎区域 -->
       <div class="mb-4">
-        <h1 class="text-3xl font-display font-bold text-gray-900 mb-2">支出记录</h1>
-        <p class="text-sm text-gray-600 font-medium">今天是 {{ currentDate }}</p>
+        <PageHeader title="支出记录" :description="`今天是 ${currentDate}`" />
       </div>
 
       <!-- 搜索框和筛选器 -->
@@ -98,7 +97,7 @@
             :disabled="!!currentFilter"
             @click="handleSearch"
           >
-            {{ currentFilter ? '搜索（已禁用）' : '搜索' }}
+            {{ currentFilter ? '查询（已禁用）' : '查询' }}
           </van-button>
         </div>
       </div>
@@ -179,6 +178,7 @@ import { useFilterStore } from '@/stores/filter';
 import ExpenseList from '@/components/ExpenseList.vue';
 import ExpenseForm from '@/components/ExpenseForm.vue';
 import FilterManager from '@/components/FilterManager.vue';
+import PageHeader from '@/components/PageHeader.vue';
 import type { ExpenseQuery } from '@/api/expense';
 import type { FilterData } from '@/api/filter';
 import dayjs from '@/utils/dayjs';

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container mx-auto px-4">
+  <div class="container mx-auto px-4 pt-6">
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
 
       <!-- 预算卡片 -->
@@ -36,10 +36,10 @@
           <div class="w-full bg-warm-100 rounded-full h-3 overflow-hidden shadow-inner">
             <div
               class="h-3 rounded-full transition-all duration-500 ease-out relative overflow-hidden"
-              :class="isOverBudget ? 'bg-gradient-to-r from-red-500 to-red-600' : 'bg-gradient-to-r from-warm-400 to-warm-600'"
+              :class="isOverBudget ? 'bg-red-600' : 'bg-warm-500'"
               :style="{ width: `${Math.min(actualProgress, 100)}%` }"
             >
-              <div class="absolute inset-0 bg-white/20 animate-shimmer"></div>
+              <div class="absolute inset-0 bg-white/15"></div>
             </div>
           </div>
           <div class="flex justify-between items-center text-sm">

--- a/frontend/src/views/More.vue
+++ b/frontend/src/views/More.vue
@@ -1,0 +1,100 @@
+<template>
+  <div>
+    <div class="mx-auto px-4 pb-6 pt-2">
+      <div class="mb-4">
+        <PageHeader title="更多" />
+      </div>
+
+      <div class="bg-white/90 backdrop-blur-sm rounded-2xl shadow-warm overflow-hidden p-3">
+        <div class="grid grid-cols-2 gap-3">
+          <button
+            type="button"
+            class="group w-full rounded-2xl border border-warm-200 bg-[color:var(--color-warm-50)] px-3.5 py-3 active:bg-white"
+            @click="router.push('/categories')"
+          >
+            <div class="flex items-center justify-between gap-3">
+              <div class="flex items-center gap-3 min-w-0">
+                <div
+                  class="w-10 h-10 rounded-2xl bg-white border border-warm-200 flex items-center justify-center text-warm-600"
+                >
+                  <van-icon name="apps-o" size="18" />
+                </div>
+                <div class="min-w-0 text-left">
+                  <div class="text-sm font-semibold text-slate-900 truncate">分类管理</div>
+                  <div class="text-xs text-slate-500 truncate">分类与标签</div>
+                </div>
+              </div>
+              <van-icon name="arrow" class="text-slate-400 group-active:text-slate-500" />
+            </div>
+          </button>
+
+          <button
+            type="button"
+            class="group w-full rounded-2xl border border-warm-200 bg-[color:var(--color-warm-50)] px-3.5 py-3 active:bg-white"
+            @click="router.push('/reports')"
+          >
+            <div class="flex items-center justify-between gap-3">
+              <div class="flex items-center gap-3 min-w-0">
+                <div
+                  class="w-10 h-10 rounded-2xl bg-white border border-warm-200 flex items-center justify-center text-warm-600"
+                >
+                  <van-icon name="chart-trending-o" size="18" />
+                </div>
+                <div class="min-w-0 text-left">
+                  <div class="text-sm font-semibold text-slate-900 truncate">支出分析</div>
+                  <div class="text-xs text-slate-500 truncate">趋势与分类</div>
+                </div>
+              </div>
+              <van-icon name="arrow" class="text-slate-400 group-active:text-slate-500" />
+            </div>
+          </button>
+        </div>
+      </div>
+
+      <div class="mt-4">
+        <button
+          type="button"
+          class="w-full bg-white/90 backdrop-blur-sm rounded-2xl shadow-warm overflow-hidden"
+          @click="handleLogout"
+        >
+          <div class="px-4 py-3.5 flex items-center justify-between">
+            <div class="flex items-center gap-3 min-w-0">
+              <div
+                class="w-10 h-10 rounded-2xl bg-red-50 border border-red-200 flex items-center justify-center text-red-600"
+              >
+                <van-icon name="warning-o" size="18" />
+              </div>
+              <div class="min-w-0 text-left">
+                <div class="text-sm font-semibold text-red-600">退出登录</div>
+                <div class="text-xs text-slate-500">将返回登录页</div>
+              </div>
+            </div>
+            <van-icon name="arrow" class="text-slate-400" />
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import PageHeader from '@/components/PageHeader.vue'
+import { useAuthStore } from '@/stores/auth'
+
+const router = useRouter()
+const authStore = useAuthStore()
+
+const handleLogout = async () => {
+  try {
+    await showConfirmDialog({
+      title: '退出登录',
+      message: '确定要退出登录吗'
+    })
+  } catch {
+    return
+  }
+
+  await authStore.logout()
+}
+</script>
+

--- a/frontend/src/views/Reports.vue
+++ b/frontend/src/views/Reports.vue
@@ -1,10 +1,9 @@
 <template>
-  <div class="min-h-screen">
+  <div>
     <div class="mx-auto px-4 pb-6 pt-2">
       <!-- 欢迎区域 -->
       <div class="mb-4">
-        <h1 class="text-3xl font-display font-bold text-gray-900 mb-2">报表分析</h1>
-        <p class="text-sm text-gray-600 font-medium">今天是 {{ currentDate }}</p>
+        <PageHeader title="支出分析" :description="`今天是 ${currentDate}`" />
       </div>
 
       <!-- 搜索区域 -->
@@ -99,6 +98,7 @@
 <script setup lang="ts">
 import TrendAnalysis from '@/components/TrendAnalysis.vue';
 import CategoryAnalysis from '@/components/CategoryAnalysis.vue';
+import PageHeader from '@/components/PageHeader.vue';
 import { useReportStore } from '@/stores/report';
 import { formatAmount } from '@/utils/format';
 import type { ReportData } from '@/api/report';


### PR DESCRIPTION
- 新增日历查询组件与月视图面板，支持按月份范围（最多三个月）查询支出统计
- 新增「更多」页面入口，底部导航调整为 首页/支出/日历/更多，并兼容子页面高亮
- 抽取通用 `PageHeader` 统一页面标题展示，补充统计接口响应类型定义
- 全局样式去除阴影/边框/动效，统一视觉表现