### PR TITLE
feat(frontend): 支持从日历点击跳转到指定日期的支出列表并优化交互样式

### DIFF
--- a/frontend/src/components/CalendarMonthPanel.vue
+++ b/frontend/src/components/CalendarMonthPanel.vue
@@ -16,7 +16,7 @@
         :show-title="false"
         :show-confirm="false"
         :lazy-render="false"
-        :readonly="true"
+        :readonly="false"
         :show-mark="false"
         :show-subtitle="false"
         :row-height="64"
@@ -25,6 +25,7 @@
         :default-date="defaultDate"
         :formatter="formatDay"
         :safe-area-inset-bottom="false"
+        @select="handleSelect"
       />
     </div>
   </section>
@@ -38,6 +39,10 @@ import { formatAmount } from '@/utils/format'
 const props = defineProps<{
   monthStart: dayjs.Dayjs
   byDate: Record<string, number>
+}>()
+
+const emit = defineEmits<{
+  (e: 'select-expense-date', payload: { date: string }): void
 }>()
 
 const minDate = computed(() => props.monthStart.startOf('month').toDate())
@@ -93,6 +98,29 @@ const formatDay = (day: CalendarDayItem) => {
   }
 
   return day
+}
+
+const handleSelect = (value: Date | Date[]) => {
+  if (Array.isArray(value)) {
+    return
+  }
+
+  const d = dayjs(value)
+  if (!d.isValid()) {
+    return
+  }
+
+  if (!d.isSame(props.monthStart, 'month')) {
+    return
+  }
+
+  const key = d.format('YYYY-MM-DD')
+  const amount = props.byDate[key] || 0
+  if (amount <= 0) {
+    return
+  }
+
+  emit('select-expense-date', { date: key })
 }
 </script>
 

--- a/frontend/src/components/ExpenseListItem.vue
+++ b/frontend/src/components/ExpenseListItem.vue
@@ -156,7 +156,12 @@ const handleDelete = () => {
 
 :deep(.van-cell:hover) {
   background: var(--color-warm-50);
-  transform: translateX(4px);
+  transform: none;
+}
+
+:deep(.van-cell:active) {
+  background: var(--color-warm-100);
+  transform: none;
 }
 
 :deep(.van-cell::after) {

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-screen overflow-hidden bg-gradient-warm-subtle flex flex-col">
+  <div class="h-[100dvh] overflow-hidden bg-gradient-warm-subtle flex flex-col">
     <!-- 中间内容区域 -->
     <main class="flex-1 min-h-0 overflow-y-auto">
       <div class="container mx-auto pt-2 pb-2">
@@ -15,7 +15,7 @@
       :fixed="false"
       safe-area-inset-bottom
       :border="false"
-      class="md:hidden bg-transparent"
+      class="md:hidden bg-transparent flex-shrink-0"
       @change="handleTabChange"
     >
       <van-tabbar-item

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -65,7 +65,6 @@
   body {
     margin: 0;
     min-width: 320px;
-    min-height: 100vh;
     background: linear-gradient(to bottom, var(--color-warm-50), #ffffff);
   }
   

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,10 +1,11 @@
+// 桌面端将 mouse 转为 touch，使 SwipeCell 等仅监听 touch 的组件可正常使用（见 Vant 进阶用法-桌面端适配）
+import '@vant/touch-emulator'
+
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
 import './main.css'
-// 桌面端将 mouse 转为 touch，使 NumberKeyboard 等仅监听 touch 的组件可正常使用（见 Vant 进阶用法-桌面端适配）
-import '@vant/touch-emulator'
 
 const app = createApp(App)
 const pinia = createPinia()

--- a/frontend/src/views/Calendar.vue
+++ b/frontend/src/views/Calendar.vue
@@ -21,6 +21,7 @@
           :key="month.format('YYYY-MM')"
           :month-start="month"
           :by-date="byDate"
+          @select-expense-date="handleSelectExpenseDate"
         />
       </div>
     </div>
@@ -36,6 +37,7 @@ import CalendarMonthPanel from '@/components/CalendarMonthPanel.vue'
 
 const loading = ref(true)
 const byDate = ref<Record<string, number>>({})
+const router = useRouter()
 
 const queryStartMonth = ref(dayjs().subtract(2, 'month').format('YYYY-MM'))
 const queryEndMonth = ref(dayjs().format('YYYY-MM'))
@@ -69,6 +71,13 @@ const handleSearch = async (payload: { startMonth: string; endMonth: string }) =
   queryStartMonth.value = payload.startMonth
   queryEndMonth.value = payload.endMonth
   await load()
+}
+
+const handleSelectExpenseDate = (payload: { date: string }) => {
+  router.push({
+    path: '/expenses',
+    query: { startDate: payload.date, endDate: payload.date }
+  })
 }
 
 const load = async () => {

--- a/frontend/src/views/Expenses.vue
+++ b/frontend/src/views/Expenses.vue
@@ -400,7 +400,33 @@ const fetchExpenses = async () => {
 
 // 在组件挂载时设置默认日期范围并加载数据
 onMounted(async () => {
-  setDefaultDateRange();
+  const startParam = typeof route.query.startDate === 'string' ? route.query.startDate : ''
+  const endParam = typeof route.query.endDate === 'string' ? route.query.endDate : ''
+
+  const parsedStart = startParam ? dayjs(startParam) : null
+  const parsedEnd = endParam ? dayjs(endParam) : null
+
+  if (parsedStart && parsedStart.isValid() && parsedEnd && parsedEnd.isValid()) {
+    const start = parsedStart
+    const end = parsedEnd
+
+    query.startDate = start.format('YYYY-MM-DD')
+    query.endDate = end.format('YYYY-MM-DD')
+
+    currentStartDate.value = [
+      start.year().toString(),
+      (start.month() + 1).toString().padStart(2, '0'),
+      start.date().toString().padStart(2, '0')
+    ]
+
+    currentEndDate.value = [
+      end.year().toString(),
+      (end.month() + 1).toString().padStart(2, '0'),
+      end.date().toString().padStart(2, '0')
+    ]
+  } else {
+    setDefaultDateRange()
+  }
   
   // 处理路由查询参数，设置搜索框内容
   if (route.query.category) {

--- a/frontend/src/views/More.vue
+++ b/frontend/src/views/More.vue
@@ -5,50 +5,48 @@
         <PageHeader title="更多" />
       </div>
 
-      <div class="bg-white/90 backdrop-blur-sm rounded-2xl shadow-warm overflow-hidden p-3">
-        <div class="grid grid-cols-2 gap-3">
-          <button
-            type="button"
-            class="group w-full rounded-2xl border border-warm-200 bg-[color:var(--color-warm-50)] px-3.5 py-3 active:bg-white"
-            @click="router.push('/categories')"
-          >
-            <div class="flex items-center justify-between gap-3">
-              <div class="flex items-center gap-3 min-w-0">
-                <div
-                  class="w-10 h-10 rounded-2xl bg-white border border-warm-200 flex items-center justify-center text-warm-600"
-                >
-                  <van-icon name="apps-o" size="18" />
-                </div>
-                <div class="min-w-0 text-left">
-                  <div class="text-sm font-semibold text-slate-900 truncate">分类管理</div>
-                  <div class="text-xs text-slate-500 truncate">分类与标签</div>
-                </div>
+      <div class="space-y-3">
+        <button
+          type="button"
+          class="group w-full bg-white/90 backdrop-blur-sm rounded-2xl shadow-warm overflow-hidden"
+          @click="router.push('/categories')"
+        >
+          <div class="px-4 py-4 flex items-start justify-between gap-4">
+            <div class="flex items-start gap-3.5 min-w-0">
+              <div
+                class="w-11 h-11 rounded-2xl bg-[color:var(--color-warm-50)] border border-warm-200 flex items-center justify-center text-warm-600 flex-shrink-0"
+              >
+                <van-icon name="apps-o" size="18" />
               </div>
-              <van-icon name="arrow" class="text-slate-400 group-active:text-slate-500" />
+              <div class="min-w-0 text-left">
+                <div class="text-sm font-semibold text-slate-900 leading-snug">分类管理</div>
+                <div class="mt-1 text-xs text-slate-500 leading-snug break-words">分类与标签</div>
+              </div>
             </div>
-          </button>
+            <van-icon name="arrow" class="text-slate-400 group-active:text-slate-500 mt-1" />
+          </div>
+        </button>
 
-          <button
-            type="button"
-            class="group w-full rounded-2xl border border-warm-200 bg-[color:var(--color-warm-50)] px-3.5 py-3 active:bg-white"
-            @click="router.push('/reports')"
-          >
-            <div class="flex items-center justify-between gap-3">
-              <div class="flex items-center gap-3 min-w-0">
-                <div
-                  class="w-10 h-10 rounded-2xl bg-white border border-warm-200 flex items-center justify-center text-warm-600"
-                >
-                  <van-icon name="chart-trending-o" size="18" />
-                </div>
-                <div class="min-w-0 text-left">
-                  <div class="text-sm font-semibold text-slate-900 truncate">支出分析</div>
-                  <div class="text-xs text-slate-500 truncate">趋势与分类</div>
-                </div>
+        <button
+          type="button"
+          class="group w-full bg-white/90 backdrop-blur-sm rounded-2xl shadow-warm overflow-hidden"
+          @click="router.push('/reports')"
+        >
+          <div class="px-4 py-4 flex items-start justify-between gap-4">
+            <div class="flex items-start gap-3.5 min-w-0">
+              <div
+                class="w-11 h-11 rounded-2xl bg-[color:var(--color-warm-50)] border border-warm-200 flex items-center justify-center text-warm-600 flex-shrink-0"
+              >
+                <van-icon name="chart-trending-o" size="18" />
               </div>
-              <van-icon name="arrow" class="text-slate-400 group-active:text-slate-500" />
+              <div class="min-w-0 text-left">
+                <div class="text-sm font-semibold text-slate-900 leading-snug">支出分析</div>
+                <div class="mt-1 text-xs text-slate-500 leading-snug break-words">趋势与分类</div>
+              </div>
             </div>
-          </button>
-        </div>
+            <van-icon name="arrow" class="text-slate-400 group-active:text-slate-500 mt-1" />
+          </div>
+        </button>
       </div>
 
       <div class="mt-4">
@@ -66,7 +64,6 @@
               </div>
               <div class="min-w-0 text-left">
                 <div class="text-sm font-semibold text-red-600">退出登录</div>
-                <div class="text-xs text-slate-500">将返回登录页</div>
               </div>
             </div>
             <van-icon name="arrow" class="text-slate-400" />


### PR DESCRIPTION
支持在月视图点击有支出的日期，跳转到支出列表并自动填充起止日期范围；同时优化桌面端触摸适配引入顺序、列表项交互态与更多页布局，修复移动端视口高度表现。