### PR TITLE
feat: 语音记账（MiMo ASR + AI 解析）

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -104,6 +104,10 @@ jobs:
           export NODE_ENV=production
           export MONGODB_URI=${{ secrets.MONGODB_URI }}
           export JWT_SECRET=${{ secrets.JWT_SECRET }}
+          export MIMO_API_KEY=${{ secrets.MIMO_API_KEY }}
+          export MIMO_BASE_URL=${{ secrets.MIMO_BASE_URL }}
+          export MIMO_MODEL=${{ secrets.MIMO_MODEL }}
+          export MIMO_ASR_MODEL=${{ secrets.MIMO_ASR_MODEL }}
           
           # 安装 pnpm（如果尚未安装）
           if ! command -v pnpm &> /dev/null; then

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,3 +22,14 @@ PASSWORD_SALT_ROUNDS=10
 # 运行环境
 # 可选值：development, production, test
 NODE_ENV=development
+
+# 小米 MiMo API（语音解析 + 语音识别）
+MIMO_API_KEY=your_mimo_api_key
+MIMO_BASE_URL=https://token-plan-sgp.xiaomimimo.com/v1
+MIMO_MODEL=mimo-v2.5-pro
+MIMO_ASR_MODEL=mimo-v2.5-asr
+
+# 科大讯飞 API（可选，ASR 备用）
+XFYUN_APP_ID=your_xfyun_app_id
+XFYUN_API_KEY=your_xfyun_api_key
+XFYUN_API_SECRET=your_xfyun_api_secret

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,8 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
-    "mongoose": "^7.0.3"
+    "mongoose": "^7.0.3",
+    "multer": "^2.2.0"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
@@ -32,6 +33,7 @@
     "@types/jest": "^29.5.0",
     "@types/jsonwebtoken": "^9.0.1",
     "@types/ms": "^2.1.0",
+    "@types/multer": "^2.2.0",
     "@types/node": "^18.19.103",
     "jest": "^29.5.0",
     "nodemon": "^3.1.10",

--- a/backend/src/controllers/voice.ts
+++ b/backend/src/controllers/voice.ts
@@ -1,0 +1,69 @@
+import { Response } from 'express';
+import { AuthenticatedRequest } from '../middlewares/auth';
+import { transcribeAudio } from '../services/mimo/asr';
+import { parseExpenseText } from '../services/mimo/parseExpense';
+import { resolveExpenseCategoryId } from '../services/voice/resolveCategory';
+import {
+  getAvailableTagsForPrompt,
+  resolveExpenseTagIds,
+} from '../services/voice/resolveTags';
+import { validateExpenseTags } from '../utils/tag';
+
+export const expenseFromVoice = async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    if (!req.user?._id || !req.user?.roomNumber) {
+      return res.status(401).json({ message: '未授权访问' });
+    }
+
+    if (!req.file?.buffer?.length) {
+      return res.status(400).json({ message: '请上传音频文件' });
+    }
+
+    const mimeType = req.file.mimetype || 'audio/wav';
+    const availableTags = await getAvailableTagsForPrompt(req.user.roomNumber);
+    const rawText = await transcribeAudio(req.file.buffer, mimeType);
+    const parsed = await parseExpenseText(rawText, {
+      availableTagNames: availableTags.map((tag) => tag.name),
+    });
+    const categoryId = await resolveExpenseCategoryId(
+      req.user._id,
+      req.user.roomNumber,
+      parsed.categoryName
+    );
+
+    if (!categoryId) {
+      return res.status(400).json({ message: '未找到可用分类，请先在分类管理中启用分类' });
+    }
+
+    const resolvedTags = await resolveExpenseTagIds(
+      req.user.roomNumber,
+      parsed.tagNames,
+      parsed.date
+    );
+    const validatedTags = await validateExpenseTags({
+      tagIds: resolvedTags.map((tag) => tag.id),
+      date: parsed.date,
+      roomNumber: req.user.roomNumber,
+    });
+
+    if (validatedTags.error) {
+      return res.status(400).json({ message: validatedTags.error });
+    }
+
+    res.json({
+      rawText,
+      amount: parsed.amount,
+      categoryName: parsed.categoryName,
+      categoryId,
+      description: parsed.description,
+      date: parsed.date,
+      isExtra: parsed.isExtra,
+      tags: resolvedTags.map((tag) => tag.id),
+      tagNames: resolvedTags.map((tag) => tag.name),
+    });
+  } catch (error) {
+    console.error('语音记账失败:', error);
+    const message = error instanceof Error ? error.message : '语音记账失败';
+    res.status(500).json({ message });
+  }
+};

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -10,6 +10,7 @@ import healthRoutes from './health';
 import budgetRoutes from './budget';
 import reportRoutes from './report';
 import filterRoutes from './filter';
+import voiceRoutes from './voice';
 
 const router: Router = Router();
 
@@ -24,5 +25,6 @@ router.use('/health', healthRoutes);
 router.use('/budgets', budgetRoutes);
 router.use('/reports', reportRoutes);
 router.use('/filters', filterRoutes);
+router.use('/voice', voiceRoutes);
 
 export default router; 

--- a/backend/src/routes/voice.ts
+++ b/backend/src/routes/voice.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import multer from 'multer';
+import { auth } from '../middlewares/auth';
+import { expenseFromVoice } from '../controllers/voice';
+
+const router: Router = Router();
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: 10 * 1024 * 1024,
+  },
+});
+
+router.use(auth);
+router.post('/expense-from-voice', upload.single('audio'), expenseFromVoice);
+
+export default router;

--- a/backend/src/services/mimo/asr.ts
+++ b/backend/src/services/mimo/asr.ts
@@ -1,0 +1,32 @@
+import { mimoChat } from './client';
+
+export async function transcribeAudio(audioBuffer: Buffer, mimeType = 'audio/wav'): Promise<string> {
+  const base64 = audioBuffer.toString('base64');
+
+  const result = await mimoChat({
+    model: process.env.MIMO_ASR_MODEL || 'mimo-v2.5-asr',
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'input_audio',
+            input_audio: {
+              data: `data:${mimeType};base64,${base64}`,
+            },
+          },
+        ],
+      },
+    ],
+    asr_options: {
+      language: 'zh',
+    },
+  });
+
+  const text = result.choices[0]?.message?.content?.trim();
+  if (!text) {
+    throw new Error('未能识别语音内容，请重试');
+  }
+
+  return text;
+}

--- a/backend/src/services/mimo/client.ts
+++ b/backend/src/services/mimo/client.ts
@@ -1,0 +1,38 @@
+interface MimoChatCompletionResponse {
+  choices: Array<{
+    message: {
+      content: string | null;
+    };
+  }>;
+}
+
+const getMimoConfig = () => {
+  const baseUrl = process.env.MIMO_BASE_URL;
+  const apiKey = process.env.MIMO_API_KEY;
+
+  if (!baseUrl || !apiKey) {
+    throw new Error('MiMo API 未配置，请设置 MIMO_BASE_URL 和 MIMO_API_KEY');
+  }
+
+  return { baseUrl: baseUrl.replace(/\/$/, ''), apiKey };
+};
+
+export async function mimoChat(body: Record<string, unknown>): Promise<MimoChatCompletionResponse> {
+  const { baseUrl, apiKey } = getMimoConfig();
+
+  const response = await fetch(`${baseUrl}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'api-key': apiKey,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`MiMo API 请求失败: ${response.status} ${errorText}`);
+  }
+
+  return response.json() as Promise<MimoChatCompletionResponse>;
+}

--- a/backend/src/services/mimo/parseExpense.ts
+++ b/backend/src/services/mimo/parseExpense.ts
@@ -1,0 +1,116 @@
+import dayjs from 'dayjs';
+import { mimoChat } from './client';
+import { systemCategories } from '../../models/category';
+
+export interface ParsedExpenseFields {
+  amount: number;
+  categoryName: string;
+  description: string;
+  date: string;
+  isExtra: boolean;
+  tagNames: string[];
+}
+
+export interface ParseExpenseContext {
+  today?: string;
+  availableTagNames?: string[];
+}
+
+const expenseCategoryNames = systemCategories
+  .filter((category) => category.type === 'expense')
+  .map((category) => category.name);
+
+const normalizeTagNames = (
+  tagNames: unknown,
+  availableTagNames: string[]
+): string[] => {
+  if (!Array.isArray(tagNames)) {
+    return [];
+  }
+
+  const availableSet = new Set(availableTagNames);
+  return tagNames
+    .filter((name): name is string => typeof name === 'string')
+    .map((name) => name.trim())
+    .filter((name) => availableSet.has(name));
+};
+
+const normalizeParsedExpense = (
+  parsed: Partial<ParsedExpenseFields> & { tagNames?: unknown },
+  today: string,
+  availableTagNames: string[]
+): ParsedExpenseFields => {
+  const amount = Number(parsed.amount);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new Error('未能识别有效金额');
+  }
+
+  const categoryName = expenseCategoryNames.includes(parsed.categoryName || '')
+    ? parsed.categoryName!
+    : '其他';
+
+  const date = parsed.date && dayjs(parsed.date, 'YYYY-MM-DD', true).isValid()
+    ? parsed.date
+    : today;
+
+  return {
+    amount: Math.round(amount * 100) / 100,
+    categoryName,
+    description: (parsed.description || '').trim().slice(0, 200),
+    date,
+    isExtra: parsed.isExtra === true,
+    tagNames: normalizeTagNames(parsed.tagNames, availableTagNames),
+  };
+};
+
+export async function parseExpenseText(
+  text: string,
+  context: ParseExpenseContext = {}
+): Promise<ParsedExpenseFields> {
+  const today = context.today || dayjs().format('YYYY-MM-DD');
+  const availableTagNames = context.availableTagNames || [];
+  const tagPrompt = availableTagNames.length > 0
+    ? `可用标签（tagNames 只能从中选择，可多个）：${availableTagNames.join('、')}`
+    : '当前没有可用标签，tagNames 返回空数组 []';
+
+  const result = await mimoChat({
+    model: process.env.MIMO_MODEL || 'mimo-v2.5-pro',
+    messages: [
+      {
+        role: 'system',
+        content: `你是家庭账本助手。将用户的口语记账内容解析为 JSON，只输出 JSON。
+可用支出分类：${expenseCategoryNames.join('、')}
+${tagPrompt}
+字段说明：
+- amount: 数字，必须大于 0
+- categoryName: 必须从可用分类中选择最接近的一项
+- description: 简短描述，可为空字符串
+- date: YYYY-MM-DD 格式；今天日期是 ${today}，请把“今天/昨天/前天”等换算成具体日期
+- isExtra: 布尔值；当用户明确说这是额外支出、不计入预算、人情往来、大件采购等时才为 true，否则为 false
+- tagNames: 字符串数组；仅当用户明确提到某个可用标签名称时才加入，不要猜测`,
+      },
+      {
+        role: 'user',
+        content: text,
+      },
+    ],
+    max_completion_tokens: 320,
+    temperature: 0.1,
+    thinking: { type: 'disabled' },
+    response_format: { type: 'json_object' },
+  });
+
+  const content = result.choices[0]?.message?.content;
+  if (!content) {
+    throw new Error('AI 未能解析记账内容');
+  }
+
+  let parsed: Partial<ParsedExpenseFields> & { tagNames?: unknown };
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    throw new Error('AI 返回格式无效');
+  }
+
+  return normalizeParsedExpense(parsed, today, availableTagNames);
+}

--- a/backend/src/services/voice/resolveCategory.ts
+++ b/backend/src/services/voice/resolveCategory.ts
@@ -1,0 +1,44 @@
+import { Types } from 'mongoose';
+import { Category } from '../../models/category';
+import { UserCategory } from '../../models/user-category';
+
+export async function resolveExpenseCategoryId(
+  userId: string,
+  roomNumber: string,
+  categoryName: string
+): Promise<string | null> {
+  const disabledPermissions = await UserCategory.find({
+    userId: new Types.ObjectId(userId),
+    isDisabled: true,
+  });
+  const disabledCategoryIds = new Set(
+    disabledPermissions.map((permission) => permission.categoryId.toString())
+  );
+
+  const systemCategory = await Category.findOne({
+    isSystem: true,
+    type: 'expense',
+    name: categoryName,
+  });
+
+  if (systemCategory && !disabledCategoryIds.has(systemCategory._id.toString())) {
+    return systemCategory._id.toString();
+  }
+
+  const customCategory = await Category.findOne({
+    isSystem: false,
+    type: 'expense',
+    roomNumber,
+    name: categoryName,
+  });
+
+  if (customCategory) {
+    return customCategory._id.toString();
+  }
+
+  if (categoryName !== '其他') {
+    return resolveExpenseCategoryId(userId, roomNumber, '其他');
+  }
+
+  return systemCategory?._id.toString() || null;
+}

--- a/backend/src/services/voice/resolveTags.ts
+++ b/backend/src/services/voice/resolveTags.ts
@@ -1,0 +1,51 @@
+import { Types } from 'mongoose';
+import { Tag } from '../../models/tag';
+import { isTagActiveOnDate, normalizeTagDate } from '../../utils/tag';
+
+export interface ResolvedTag {
+  id: string;
+  name: string;
+}
+
+export async function getAvailableTagsForPrompt(roomNumber: string): Promise<Array<{ id: string; name: string }>> {
+  const tags = await Tag.find({ roomNumber, archived: false }).sort({ name: 1 });
+  return tags.map((tag) => ({
+    id: tag._id.toString(),
+    name: tag.name,
+  }));
+}
+
+export async function resolveExpenseTagIds(
+  roomNumber: string,
+  tagNames: string[],
+  expenseDate: string
+): Promise<ResolvedTag[]> {
+  if (tagNames.length === 0) {
+    return [];
+  }
+
+  const tags = await Tag.find({ roomNumber, archived: false });
+  const expenseDateValue = normalizeTagDate(expenseDate);
+  const normalizedNames = new Set(tagNames.map((name) => name.trim()).filter(Boolean));
+  const resolved: ResolvedTag[] = [];
+
+  for (const name of normalizedNames) {
+    const matched = tags.find((tag) => tag.name === name);
+    if (!matched) {
+      continue;
+    }
+    if (!isTagActiveOnDate(matched, expenseDateValue)) {
+      continue;
+    }
+    resolved.push({
+      id: matched._id.toString(),
+      name: matched.name,
+    });
+  }
+
+  return resolved;
+}
+
+export const toObjectIds = (tags: ResolvedTag[]): Types.ObjectId[] => {
+  return tags.map((tag) => new Types.ObjectId(tag.id));
+};

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -10,7 +10,11 @@ module.exports = {
       NODE_ENV: 'production',
       PORT: 3000,
       MONGODB_URI: process.env.MONGODB_URI,
-      JWT_SECRET: process.env.JWT_SECRET
+      JWT_SECRET: process.env.JWT_SECRET,
+      MIMO_API_KEY: process.env.MIMO_API_KEY,
+      MIMO_BASE_URL: process.env.MIMO_BASE_URL,
+      MIMO_MODEL: process.env.MIMO_MODEL,
+      MIMO_ASR_MODEL: process.env.MIMO_ASR_MODEL,
     }
   }]
 }; 

--- a/frontend/src/api/voice.ts
+++ b/frontend/src/api/voice.ts
@@ -1,0 +1,31 @@
+import axios from '@/utils/axios';
+
+export interface VoiceExpenseResult {
+  rawText: string;
+  amount: number;
+  categoryName: string;
+  categoryId: string;
+  description: string;
+  date: string;
+  isExtra: boolean;
+  tags: string[];
+  tagNames: string[];
+}
+
+class VoiceApi {
+  async expenseFromVoice(audio: Blob): Promise<VoiceExpenseResult> {
+    const formData = new FormData();
+    formData.append('audio', audio, 'recording.wav');
+
+    const response = await axios.post('/voice/expense-from-voice', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+      timeout: 60000,
+    });
+
+    return response.data;
+  }
+}
+
+export const voiceApi = new VoiceApi();

--- a/frontend/src/components/ExpenseForm.vue
+++ b/frontend/src/components/ExpenseForm.vue
@@ -16,6 +16,17 @@
 
       <!-- 表单内容 -->
       <div class="flex-1 overflow-y-auto p-6 bg-white">
+        <div
+          v-if="props.voiceRawText"
+          class="rounded-xl bg-indigo-50 border border-indigo-100 p-4 mb-5"
+        >
+          <div class="flex items-center gap-2 mb-2">
+            <van-icon name="audio" class="text-indigo-500" size="16" />
+            <p class="text-xs font-medium text-indigo-600">语音识别内容</p>
+          </div>
+          <p class="text-sm text-gray-800 leading-relaxed">{{ props.voiceRawText }}</p>
+        </div>
+
         <van-form class="space-y-5" @submit="handleSubmit">
           <!-- 日期选择 -->
           <van-field
@@ -257,6 +268,15 @@ const props = defineProps<{
     tags: string[];
     isExtra: boolean;
   };
+  initialData?: {
+    date: string;
+    category: string;
+    amount: number;
+    description: string;
+    tags?: string[];
+    isExtra?: boolean;
+  };
+  voiceRawText?: string;
 }>();
 
 // 组件事件定义
@@ -477,6 +497,26 @@ const handleShowUpdate = (value: boolean) => {
   emit('update:show', value);
 };
 
+const applyInitialData = () => {
+  if (!props.initialData) {
+    return;
+  }
+
+  form.date = props.initialData.date;
+  const dateObj = dayjs(props.initialData.date);
+  currentDate.value = [
+    dateObj.year().toString(),
+    (dateObj.month() + 1).toString().padStart(2, '0'),
+    dateObj.date().toString().padStart(2, '0')
+  ];
+  form.category = props.initialData.category;
+  form.amount = props.initialData.amount.toString();
+  form.description = props.initialData.description;
+  form.tags = [...(props.initialData.tags || [])];
+  form.isExtra = props.initialData.isExtra || false;
+  syncTagsForDate();
+};
+
 // 监听显示状态
 watch(() => props.show, async (newValue) => {
   if (newValue) {
@@ -484,7 +524,7 @@ watch(() => props.show, async (newValue) => {
     resetForm();
 
     // 如果是新增模式且有保留的日期，恢复保留的日期
-    if (!isEditMode.value && lastSubmittedDate.value) {
+    if (!isEditMode.value && !props.initialData && lastSubmittedDate.value) {
       form.date = lastSubmittedDate.value;
       const dateObj = dayjs(lastSubmittedDate.value);
       currentDate.value = [
@@ -514,7 +554,7 @@ watch(() => props.show, async (newValue) => {
         await tagStore.fetchTags();
       } catch (error) {
         console.error('Failed to fetch tags:', error);
-        showToast('获取标签列表失败');
+        showToast('获取标签失败');
       }
     }
 
@@ -535,6 +575,8 @@ watch(() => props.show, async (newValue) => {
       form.description = props.editData.description;
       form.tags = props.editData.tags;
       form.isExtra = props.editData.isExtra || false;
+    } else if (props.initialData) {
+      applyInitialData();
     } else {
       syncTagsForDate();
     }

--- a/frontend/src/components/VoiceRecordButton.vue
+++ b/frontend/src/components/VoiceRecordButton.vue
@@ -1,0 +1,176 @@
+<template>
+  <van-floating-bubble
+    class="home-floating-action home-floating-action--voice"
+    :class="{
+      'home-floating-action--recording': isRecording,
+      'home-floating-action--processing': processing,
+    }"
+    axis="xy"
+    magnetic="x"
+    :gap="{ x: 24, y: 132 }"
+    teleport="body"
+    :icon="bubbleIcon"
+    @click="handleClick"
+  />
+
+  <van-overlay :show="isRecording || processing" z-index="2000">
+    <div class="voice-overlay" @click.stop>
+      <div class="voice-overlay__panel">
+        <div
+          class="voice-overlay__pulse"
+          :class="{ 'voice-overlay__pulse--active': isRecording }"
+        ></div>
+        <p class="voice-overlay__title">
+          {{ processing ? '正在识别...' : isRecording ? '正在录音' : '' }}
+        </p>
+        <p class="voice-overlay__hint">
+          {{ processing ? '请稍候，AI 正在解析记账内容' : '说完后再次点击结束录音' }}
+        </p>
+        <van-button
+          v-if="isRecording && !processing"
+          type="primary"
+          size="small"
+          class="mt-4"
+          @click="finishRecording"
+        >
+          结束并识别
+        </van-button>
+      </div>
+    </div>
+  </van-overlay>
+</template>
+
+<script setup lang="ts">
+import { useVoiceRecorder } from '@/composables/useVoiceRecorder';
+import { voiceApi, type VoiceExpenseResult } from '@/api/voice';
+
+const emit = defineEmits<{
+  (e: 'success', value: VoiceExpenseResult): void;
+}>();
+
+const { isRecording, isSupported, start, stop, cancel } = useVoiceRecorder();
+const processing = ref(false);
+
+const bubbleIcon = computed(() => {
+  if (processing.value) {
+    return 'loading';
+  }
+  if (isRecording.value) {
+    return 'stop-circle-o';
+  }
+  return 'audio';
+});
+
+const handleClick = async () => {
+  if (processing.value) {
+    return;
+  }
+
+  if (!isSupported) {
+    showToast('当前浏览器不支持录音');
+    return;
+  }
+
+  if (!isRecording.value) {
+    try {
+      await start();
+    } catch (error) {
+      console.error('Failed to start recording:', error);
+      showToast(error instanceof Error ? error.message : '无法开始录音');
+    }
+    return;
+  }
+
+  await finishRecording();
+};
+
+const finishRecording = async () => {
+  if (processing.value || !isRecording.value) {
+    return;
+  }
+
+  processing.value = true;
+
+  try {
+    const audio = await stop();
+    if (audio.size < 1000) {
+      showToast('录音太短，请重试');
+      return;
+    }
+
+    const result = await voiceApi.expenseFromVoice(audio);
+    emit('success', result);
+  } catch (error) {
+    console.error('Voice expense failed:', error);
+    if (!error || typeof error !== 'object' || !('response' in error)) {
+      showToast(error instanceof Error ? error.message : '语音识别失败');
+    }
+  } finally {
+    processing.value = false;
+    if (isRecording.value) {
+      await cancel();
+    }
+  }
+};
+</script>
+
+<style scoped>
+.voice-overlay {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.voice-overlay__panel {
+  width: min(100%, 320px);
+  background: rgba(255, 255, 255, 0.96);
+  border-radius: 24px;
+  padding: 32px 24px;
+  text-align: center;
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.18);
+}
+
+.voice-overlay__pulse {
+  width: 72px;
+  height: 72px;
+  margin: 0 auto 16px;
+  border-radius: 9999px;
+  background: rgba(239, 68, 68, 0.12);
+  position: relative;
+}
+
+.voice-overlay__pulse--active::after {
+  content: '';
+  position: absolute;
+  inset: 12px;
+  border-radius: 9999px;
+  background: #ef4444;
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+.voice-overlay__title {
+  font-size: 18px;
+  font-weight: 700;
+  color: #111827;
+  margin-bottom: 8px;
+}
+
+.voice-overlay__hint {
+  font-size: 14px;
+  color: #6b7280;
+  line-height: 1.5;
+}
+
+@keyframes pulse {
+  0%, 100% {
+    transform: scale(0.92);
+    opacity: 0.85;
+  }
+  50% {
+    transform: scale(1.08);
+    opacity: 1;
+  }
+}
+</style>

--- a/frontend/src/composables/useVoiceRecorder.ts
+++ b/frontend/src/composables/useVoiceRecorder.ts
@@ -1,0 +1,162 @@
+const TARGET_SAMPLE_RATE = 16000;
+
+const mergeFloat32Arrays = (chunks: Float32Array[]): Float32Array => {
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const merged = new Float32Array(totalLength);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return merged;
+};
+
+const downsampleBuffer = (buffer: Float32Array, inputSampleRate: number, outputSampleRate: number) => {
+  if (outputSampleRate === inputSampleRate) {
+    return buffer;
+  }
+
+  const sampleRateRatio = inputSampleRate / outputSampleRate;
+  const newLength = Math.round(buffer.length / sampleRateRatio);
+  const result = new Float32Array(newLength);
+  let offsetResult = 0;
+  let offsetBuffer = 0;
+
+  while (offsetResult < result.length) {
+    const nextOffsetBuffer = Math.round((offsetResult + 1) * sampleRateRatio);
+    let accum = 0;
+    let count = 0;
+
+    for (let index = offsetBuffer; index < nextOffsetBuffer && index < buffer.length; index += 1) {
+      accum += buffer[index];
+      count += 1;
+    }
+
+    result[offsetResult] = count > 0 ? accum / count : 0;
+    offsetResult += 1;
+    offsetBuffer = nextOffsetBuffer;
+  }
+
+  return result;
+};
+
+const encodeWav = (samples: Float32Array, sampleRate: number): Blob => {
+  const buffer = new ArrayBuffer(44 + samples.length * 2);
+  const view = new DataView(buffer);
+
+  const writeString = (offset: number, value: string) => {
+    for (let index = 0; index < value.length; index += 1) {
+      view.setUint8(offset + index, value.charCodeAt(index));
+    }
+  };
+
+  writeString(0, 'RIFF');
+  view.setUint32(4, 36 + samples.length * 2, true);
+  writeString(8, 'WAVE');
+  writeString(12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeString(36, 'data');
+  view.setUint32(40, samples.length * 2, true);
+
+  let offset = 44;
+  for (let index = 0; index < samples.length; index += 1) {
+    const sample = Math.max(-1, Math.min(1, samples[index]));
+    view.setInt16(offset, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+    offset += 2;
+  }
+
+  return new Blob([view], { type: 'audio/wav' });
+};
+
+export function useVoiceRecorder() {
+  const isRecording = ref(false);
+  const isSupported = typeof window !== 'undefined'
+    && !!navigator.mediaDevices?.getUserMedia
+    && typeof AudioContext !== 'undefined';
+
+  let audioContext: AudioContext | null = null;
+  let mediaStream: MediaStream | null = null;
+  let processor: ScriptProcessorNode | null = null;
+  let source: MediaStreamAudioSourceNode | null = null;
+  let chunks: Float32Array[] = [];
+
+  const cleanup = async () => {
+    processor?.disconnect();
+    source?.disconnect();
+    mediaStream?.getTracks().forEach((track) => track.stop());
+    if (audioContext && audioContext.state !== 'closed') {
+      await audioContext.close();
+    }
+
+    processor = null;
+    source = null;
+    mediaStream = null;
+    audioContext = null;
+    chunks = [];
+    isRecording.value = false;
+  };
+
+  const start = async () => {
+    if (!isSupported) {
+      throw new Error('当前浏览器不支持录音');
+    }
+
+    if (isRecording.value) {
+      return;
+    }
+
+    await cleanup();
+
+    mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    audioContext = new AudioContext();
+    source = audioContext.createMediaStreamSource(mediaStream);
+    processor = audioContext.createScriptProcessor(4096, 1, 1);
+    chunks = [];
+
+    processor.onaudioprocess = (event) => {
+      chunks.push(new Float32Array(event.inputBuffer.getChannelData(0)));
+    };
+
+    source.connect(processor);
+    processor.connect(audioContext.destination);
+    isRecording.value = true;
+  };
+
+  const stop = async (): Promise<Blob> => {
+    if (!isRecording.value || !audioContext) {
+      throw new Error('当前没有进行中的录音');
+    }
+
+    const sampleRate = audioContext.sampleRate;
+    const merged = mergeFloat32Arrays(chunks);
+    const downsampled = downsampleBuffer(merged, sampleRate, TARGET_SAMPLE_RATE);
+    const wavBlob = encodeWav(downsampled, TARGET_SAMPLE_RATE);
+
+    await cleanup();
+    return wavBlob;
+  };
+
+  const cancel = async () => {
+    await cleanup();
+  };
+
+  onBeforeUnmount(() => {
+    void cleanup();
+  });
+
+  return {
+    isRecording,
+    isSupported,
+    start,
+    stop,
+    cancel,
+  };
+}

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -194,20 +194,52 @@
   }
 }
 
-/* 全局悬浮按钮样式 - 应用于 teleported 组件 */
-.van-floating-bubble {
+/* 首页悬浮操作按钮：统一尺寸，分别配色 */
+.home-floating-action {
+  --van-floating-bubble-size: 56px;
+  --van-floating-bubble-icon-size: 24px;
+  --van-floating-bubble-z-index: 1000;
+}
+
+.home-floating-action .van-icon {
+  color: white !important;
+}
+
+.home-floating-action--add {
+  background: linear-gradient(135deg, var(--color-warm-500) 0%, var(--color-warm-600) 100%) !important;
+}
+
+.home-floating-action--add:active {
+  background: linear-gradient(135deg, var(--color-warm-600) 0%, var(--color-warm-700) 100%) !important;
+}
+
+.home-floating-action--voice {
+  background: linear-gradient(135deg, #6366f1 0%, #4f46e5 100%) !important;
+}
+
+.home-floating-action--voice:active,
+.home-floating-action--voice.home-floating-action--recording {
+  background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%) !important;
+}
+
+.home-floating-action--voice.home-floating-action--processing {
+  background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%) !important;
+}
+
+/* 全局悬浮按钮样式 - 应用于 teleported 组件（未使用 home-floating-action 时的兜底） */
+.van-floating-bubble:not(.home-floating-action) {
   background: linear-gradient(135deg, var(--color-warm-500) 0%, var(--color-warm-600) 100%) !important;
   box-shadow: 0 8px 24px rgba(249, 115, 22, 0.35), 0 4px 12px rgba(249, 115, 22, 0.2) !important;
   border: 2px solid rgba(255, 255, 255, 0.3) !important;
   /* transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important; */
 }
 
-.van-floating-bubble:active {
+.van-floating-bubble:not(.home-floating-action):active {
   background: linear-gradient(135deg, var(--color-warm-600) 0%, var(--color-warm-700) 100%) !important;
   box-shadow: 0 4px 12px rgba(249, 115, 22, 0.3), 0 2px 6px rgba(249, 115, 22, 0.15) !important;
 }
 
-.van-floating-bubble .van-icon {
+.van-floating-bubble:not(.home-floating-action) .van-icon {
   color: white !important;
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.15));
 }

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -92,11 +92,19 @@
     <!-- 悬浮按钮 -->
     <van-floating-bubble
       v-if="!showAddExpenseDialog"
+      class="home-floating-action home-floating-action--add"
       axis="xy"
       magnetic="x"
       :gap="{ x: 24, y: 60 }"
+      teleport="body"
       icon="plus"
-      @click="showAddExpenseDialog = true"
+      @click="openManualExpense"
+    />
+
+    <!-- 独立语音按钮 -->
+    <VoiceRecordButton
+      v-if="!showAddExpenseDialog"
+      @success="handleVoiceSuccess"
     />
 
     <!-- 预算设置对话框 -->
@@ -104,8 +112,10 @@
 
     <!-- 添加支出对话框 -->
     <ExpenseForm 
-      v-model:show="showAddExpenseDialog" 
-      @success="handleRefresh"
+      v-model:show="showAddExpenseDialog"
+      :initial-data="voiceInitialData"
+      :voice-raw-text="voiceRawText"
+      @success="handleExpenseFormSuccess"
     />
   </div>
 </template>
@@ -120,7 +130,9 @@ import { formatAmount } from '@/utils/format'
 import BudgetDialog from '@/components/BudgetDialog.vue';
 import ExpenseForm from '@/components/ExpenseForm.vue';
 import ExpenseList from '@/components/ExpenseList.vue';
+import VoiceRecordButton from '@/components/VoiceRecordButton.vue';
 import type { ExpenseData } from '@/api/expense';
+import type { VoiceExpenseResult } from '@/api/voice';
 const router = useRouter();
 const budgetStore = useBudgetStore();
 const expenseStore = useExpenseStore();
@@ -132,6 +144,49 @@ const showBudgetDialog = ref(false);
 
 // 添加支出对话框
 const showAddExpenseDialog = ref(false);
+const voiceRawText = ref<string | undefined>(undefined);
+const voiceInitialData = ref<{
+  date: string;
+  category: string;
+  amount: number;
+  description: string;
+  tags: string[];
+  isExtra: boolean;
+} | undefined>(undefined);
+
+const clearVoicePrefill = () => {
+  voiceInitialData.value = undefined;
+  voiceRawText.value = undefined;
+};
+
+const openManualExpense = () => {
+  clearVoicePrefill();
+  showAddExpenseDialog.value = true;
+};
+
+const handleVoiceSuccess = (result: VoiceExpenseResult) => {
+  voiceRawText.value = result.rawText;
+  voiceInitialData.value = {
+    date: result.date,
+    category: result.categoryId,
+    amount: result.amount,
+    description: result.description,
+    tags: result.tags,
+    isExtra: result.isExtra,
+  };
+  showAddExpenseDialog.value = true;
+};
+
+const handleExpenseFormSuccess = async () => {
+  clearVoicePrefill();
+  await handleRefresh();
+};
+
+watch(showAddExpenseDialog, (value) => {
+  if (!value) {
+    clearVoicePrefill();
+  }
+});
 
 // 本月支出 - 使用本月支出数据计算（排除额外支出）
 const monthlyExpense = computed(() => {
@@ -242,4 +297,4 @@ watch(() => dayjs().month(), async (newMonth) => {
   background: var(--color-warm-50);
   border-color: var(--color-warm-400);
 }
-</style> 
+</style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       mongoose:
         specifier: ^7.0.3
         version: 7.8.7
+      multer:
+        specifier: ^2.2.0
+        version: 2.2.0
     devDependencies:
       '@types/bcrypt':
         specifier: ^5.0.2
@@ -67,6 +70,9 @@ importers:
       '@types/ms':
         specifier: ^2.1.0
         version: 2.1.0
+      '@types/multer':
+        specifier: ^2.2.0
+        version: 2.2.0
       '@types/node':
         specifier: ^18.19.103
         version: 18.19.103
@@ -1291,6 +1297,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/multer@2.2.0':
+    resolution: {integrity: sha512-3U1troeqGV8Ntp7Q3klwf4zr23VEoqYVocYXaswm9+8z3O9UHDYAqLxjJ/h550iRADTjKdOdhhasXw6gD6kYtg==}
+
   '@types/node@18.19.103':
     resolution: {integrity: sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==}
 
@@ -1464,6 +1473,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  append-field@1.0.0:
+    resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
+
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
@@ -1603,6 +1615,10 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -1692,6 +1708,10 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -2777,6 +2797,10 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
+  multer@2.2.0:
+    resolution: {integrity: sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==}
+    engines: {node: '>= 10.16.0'}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -3048,6 +3072,10 @@ packages:
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -3285,6 +3313,10 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
+
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
     engines: {node: '>=10'}
@@ -3312,6 +3344,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-object@3.3.0:
     resolution: {integrity: sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==}
@@ -3525,6 +3560,9 @@ packages:
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
+
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -5138,6 +5176,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/multer@2.2.0':
+    dependencies:
+      '@types/express': 4.17.22
+
   '@types/node@18.19.103':
     dependencies:
       undici-types: 5.26.5
@@ -5329,6 +5371,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  append-field@1.0.0: {}
 
   arg@4.1.3: {}
 
@@ -5528,6 +5572,10 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
+
   bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -5607,6 +5655,13 @@ snapshots:
   common-tags@1.8.2: {}
 
   concat-map@0.0.1: {}
+
+  concat-stream@2.0.0:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      typedarray: 0.0.6
 
   confbox@0.1.8: {}
 
@@ -6921,6 +6976,13 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
+  multer@2.2.0:
+    dependencies:
+      append-field: 1.0.0
+      busboy: 1.6.0
+      concat-stream: 2.0.0
+      type-is: 1.6.18
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -7167,6 +7229,12 @@ snapshots:
   read-cache@1.0.0:
     dependencies:
       pify: 2.3.0
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   readdirp@3.6.0:
     dependencies:
@@ -7456,6 +7524,8 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  streamsearch@1.1.0: {}
+
   string-length@4.0.2:
     dependencies:
       char-regex: 1.0.2
@@ -7511,6 +7581,10 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   stringify-object@3.3.0:
     dependencies:
@@ -7779,6 +7853,8 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
+
+  typedarray@0.0.6: {}
 
   typescript@5.8.3: {}
 


### PR DESCRIPTION
## Summary
- 新增语音记账：MiMo ASR 转写 + MiMo Pro 解析金额/分类/日期/标签/额外支出，识别结果预填「新增支出」表单并展示原文
- 首页增加独立可拖拽麦克风悬浮按钮，与「+」按钮统一 56px 尺寸
- 部署链路补充 MiMo 环境变量（GitHub Secrets → SSH 部署 → PM2）

## Test plan
- [ ] 本地 `backend/.env` 配置 MiMo 密钥后，`pnpm dev` 启动前后端
- [ ] 首页麦克风录音 → 表单预填 → 保存成功
- [ ] 说「额外支出」「标签名」验证 isExtra / tags 识别
- [ ] 合并后在 GitHub Settings → Secrets 添加 `MIMO_*` 变量，再 merge 到 main 触发部署

## 线上 .env 同步说明
`.env` 不会也不应提交到 Git。合并后请在 GitHub 仓库 **Settings → Secrets and variables → Actions** 添加：
- `MIMO_API_KEY`
- `MIMO_BASE_URL`（如 `https://token-plan-sgp.xiaomimimo.com/v1`）
- `MIMO_MODEL`（可选，默认 `mimo-v2.5-pro`）
- `MIMO_ASR_MODEL`（可选，默认 `mimo-v2.5-asr`）

部署脚本会自动注入 PM2；也可 SSH 到服务器手动编辑 `backend/.env` 作为备用方案。


Made with [Cursor](https://cursor.com)