### PR TITLE
fix: 使用原生 scp 修复部署上传失败

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -87,14 +87,24 @@ jobs:
         fi
 
     - name: Upload build artifacts to server
-      uses: appleboy/scp-action@v0.1.7
-      with:
-        host: ${{ secrets.ALIYUN_HOST }}
-        username: ${{ secrets.ALIYUN_USERNAME }}
-        key: ${{ secrets.ALIYUN_SSH_KEY }}
-        source: "backend/dist,frontend/dist"
-        target: "/home/family-accounting-system"
-        overwrite: true
+      env:
+        SSH_PRIVATE_KEY: ${{ secrets.ALIYUN_SSH_KEY }}
+        SSH_HOST: ${{ secrets.ALIYUN_HOST }}
+        SSH_USER: ${{ secrets.ALIYUN_USERNAME }}
+      run: |
+        set -euo pipefail
+        mkdir -p ~/.ssh
+        printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_deploy
+        chmod 600 ~/.ssh/id_deploy
+        ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+
+        tar czf /tmp/deploy-dist.tar.gz backend/dist frontend/dist
+        scp -i ~/.ssh/id_deploy -o StrictHostKeyChecking=no \
+          /tmp/deploy-dist.tar.gz "${SSH_USER}@${SSH_HOST}:/tmp/deploy-dist.tar.gz"
+        ssh -i ~/.ssh/id_deploy -o StrictHostKeyChecking=no \
+          "${SSH_USER}@${SSH_HOST}" \
+          "set -euo pipefail && cd /home/family-accounting-system && tar xzf /tmp/deploy-dist.tar.gz && rm -f /tmp/deploy-dist.tar.gz"
+        rm -f /tmp/deploy-dist.tar.gz
 
     - name: Deploy to Aliyun
       uses: appleboy/ssh-action@v1.2.0


### PR DESCRIPTION
## Summary
- 构建 run #31099351024 在 `Upload build artifacts to server` 步骤失败：`dial tcp: lookup ***: no such host`
- `appleboy/scp-action@v0.1.7` 在 Docker 容器内无法解析 `ALIYUN_HOST`，导致 SCP 上传失败
- 改用 GitHub runner 原生 `scp`/`ssh`：打包 `backend/dist` + `frontend/dist` 为 tar.gz 上传并在服务器解压

## Test plan
- [ ] 合并后触发 CI，确认 Upload 步骤成功
- [ ] 确认 Deploy 步骤 health check 通过
- [ ] 验证生产环境前端/后端已更新


Made with [Cursor](https://cursor.com)